### PR TITLE
add nodeSelector flag (--node) using v1beta1

### DIFF
--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -19,6 +19,7 @@ shp build create <name> [flags]
 ```
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/docs/shp_build_create.md
+++ b/docs/shp_build_create.md
@@ -17,28 +17,25 @@ shp build create <name> [flags]
 ### Options
 
 ```
-      --builder-credentials-secret string        name of the secret with builder-image pull credentials
-      --builder-image string                     image employed during the building process
-      --dockerfile string                        path to dockerfile relative to repository
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-failed-limit uint              number of failed BuildRuns to be kept (default 65535)
       --retention-succeeded-limit uint           number of succeeded BuildRuns to be kept (default 65535)
       --retention-ttl-after-failed duration      duration to delete a failed BuildRun after completion
       --retention-ttl-after-succeeded duration   duration to delete a succeeded BuildRun after completion
-      --source-bundle-image string               source bundle image location, e.g. ghcr.io/shipwright-io/sample-go/source-bundle:latest
-      --source-bundle-prune pruneOption          source bundle prune option, either Never, or AfterPull (default Never)
       --source-context-dir string                use a inner directory as context directory
-      --source-credentials-secret string         name of the secret with credentials to access the source, e.g. git or registry credentials
-      --source-revision string                   git repository source revision
-      --source-url string                        git repository source URL
-      --strategy-apiversion string               kubernetes api-version of the build-strategy resource (default "v1alpha1")
+      --source-git-clone-secret string           name of the secret with credentials to access the git source, e.g. git credentials
+      --source-git-revision string               git repository source revision
+      --source-git-url string                    git repository source URL
+      --source-oci-artifact-image string         source OCI artifact image reference, e.g. ghcr.io/shipwright-io/sample-go/source-bundle:latest
+      --source-oci-artifact-prune pruneOption    source OCI artifact image prune option, either Never, or AfterPull (default Never)
+      --source-oci-artifact-pull-secret string   name of the secret with credentials to access the OCI artifact image, e.g. registry credentials
       --strategy-kind string                     build-strategy kind (default "ClusterBuildStrategy")
       --strategy-name string                     build-strategy name (default "buildpacks-v3")
       --timeout duration                         build process timeout

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -22,6 +22,7 @@ shp build run <name> [flags]
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for run
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/docs/shp_build_run.md
+++ b/docs/shp_build_run.md
@@ -18,20 +18,18 @@ shp build run <name> [flags]
 ### Options
 
 ```
-      --buildref-apiversion string               API version of build resource to reference
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for run
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
       --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
-      --sa-generate                              generate a Kubernetes service-account for the build
       --sa-name string                           Kubernetes service-account name
       --timeout duration                         build process timeout
 ```

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -28,20 +28,18 @@ shp build upload <build-name> [path/to/source|.] [flags]
 ### Options
 
 ```
-      --buildref-apiversion string               API version of build resource to reference
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for upload
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
       --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
-      --sa-generate                              generate a Kubernetes service-account for the build
       --sa-name string                           Kubernetes service-account name
       --timeout duration                         build process timeout
 ```

--- a/docs/shp_build_upload.md
+++ b/docs/shp_build_upload.md
@@ -32,6 +32,7 @@ shp build upload <build-name> [path/to/source|.] [flags]
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -F, --follow                                   Start a build and watch its log until it completes or fails.
   -h, --help                                     help for upload
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -18,19 +18,17 @@ shp buildrun create <name> [flags]
 ### Options
 
 ```
-      --buildref-apiversion string               API version of build resource to reference
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
-      --output-credentials-secret string         name of the secret with builder-image pull credentials
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])
+      --output-image-push-secret string          name of the secret with output image push credentials
       --output-insecure                          flag to indicate an insecure container registry
       --param-value stringArray                  set of key-value pairs to pass as parameters to the buildStrategy (default [])
       --retention-ttl-after-failed duration      duration to delete the BuildRun after it failed
       --retention-ttl-after-succeeded duration   duration to delete the BuildRun after it succeeded
-      --sa-generate                              generate a Kubernetes service-account for the build
       --sa-name string                           Kubernetes service-account name
       --timeout duration                         build process timeout
 ```

--- a/docs/shp_buildrun_create.md
+++ b/docs/shp_buildrun_create.md
@@ -21,6 +21,7 @@ shp buildrun create <name> [flags]
       --buildref-name string                     name of build resource to reference
   -e, --env stringArray                          specify a key-value pair for an environment variable to set for the build container (default [])
   -h, --help                                     help for create
+      --node-selector stringArray                set of key-value pairs that correspond to labels of a node to match (default [])
       --output-image string                      image employed during the building process
       --output-image-annotation stringArray      specify a set of key-value pairs that correspond to annotations to set on the output image (default [])
       --output-image-label stringArray           specify a set of key-value pairs that correspond to labels to set on the output image (default [])

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/google/go-containerregistry v0.20.3
-	github.com/onsi/gomega v1.36.3
+	github.com/onsi/gomega v1.37.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/shipwright-io/build v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
 github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
-github.com/onsi/gomega v1.36.3 h1:hID7cr8t3Wp26+cYnfcjR6HpJ00fdogN6dqZ1t6IylU=
-github.com/onsi/gomega v1.36.3/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
+github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/shp/cmd/build/delete.go
+++ b/pkg/shp/cmd/build/delete.go
@@ -3,7 +3,7 @@ package build
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,20 +58,20 @@ func (c *DeleteCommand) Run(params *params.Params, io *genericclioptions.IOStrea
 	if err != nil {
 		return err
 	}
-	if err := clientset.ShipwrightV1alpha1().Builds(params.Namespace()).Delete(c.Cmd().Context(), c.name, v1.DeleteOptions{}); err != nil {
+	if err := clientset.ShipwrightV1beta1().Builds(params.Namespace()).Delete(c.Cmd().Context(), c.name, v1.DeleteOptions{}); err != nil {
 		return err
 	}
 
 	if c.deleteRuns {
-		var brList *buildv1alpha1.BuildRunList
-		if brList, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).List(c.cmd.Context(), v1.ListOptions{
-			LabelSelector: fmt.Sprintf("%v/name=%v", buildv1alpha1.BuildDomain, c.name),
+		var brList *buildv1beta1.BuildRunList
+		if brList, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).List(c.cmd.Context(), v1.ListOptions{
+			LabelSelector: fmt.Sprintf("%v/name=%v", buildv1beta1.BuildDomain, c.name),
 		}); err != nil {
 			return err
 		}
 
 		for _, buildrun := range brList.Items {
-			if err := clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), buildrun.Name, v1.DeleteOptions{}); err != nil {
+			if err := clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), buildrun.Name, v1.DeleteOptions{}); err != nil {
 				fmt.Fprintf(io.ErrOut, "Error deleting BuildRun %q: %v\n", buildrun.Name, err)
 			}
 		}

--- a/pkg/shp/cmd/build/list.go
+++ b/pkg/shp/cmd/build/list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 	"github.com/spf13/cobra"
@@ -59,7 +59,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 	columnNames := "NAME\tOUTPUT\tSTATUS"
 	columnTemplate := "%s\t%s\t%s\n"
 
-	var buildList *buildv1alpha1.BuildList
+	var buildList *buildv1beta1.BuildList
 	clientset, err := params.ShipwrightClientSet()
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 		return err
 	}
 
-	if buildList, err = clientset.ShipwrightV1alpha1().Builds(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
+	if buildList, err = clientset.ShipwrightV1beta1().Builds(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
 		return err
 	}
 	if len(buildList.Items) == 0 {

--- a/pkg/shp/cmd/build/run.go
+++ b/pkg/shp/cmd/build/run.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/follower"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/flags"
@@ -24,8 +24,8 @@ type RunCommand struct {
 
 	buildName     string
 	namespace     string
-	buildRunSpec  *buildv1alpha1.BuildRunSpec // stores command-line flags
-	follow        bool                        // flag to tail pod logs
+	buildRunSpec  *buildv1beta1.BuildRunSpec // stores command-line flags
+	follow        bool                       // flag to tail pod logs
 	follower      *follower.Follower
 	followerReady chan bool
 }
@@ -87,7 +87,7 @@ func (r *RunCommand) FollowerReady() bool {
 // Run creates a BuildRun resource based on Build's name informed on arguments.
 func (r *RunCommand) Run(params *params.Params, ioStreams *genericclioptions.IOStreams) error {
 	// resource using GenerateName, which will provide a unique instance
-	br := &buildv1alpha1.BuildRun{
+	br := &buildv1beta1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", r.buildName),
 		},
@@ -100,7 +100,7 @@ func (r *RunCommand) Run(params *params.Params, ioStreams *genericclioptions.IOS
 	if err != nil {
 		return err
 	}
-	br, err = clientset.ShipwrightV1alpha1().BuildRuns(r.namespace).Create(ctx, br, metav1.CreateOptions{})
+	br, err = clientset.ShipwrightV1beta1().BuildRuns(r.namespace).Create(ctx, br, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/shp/cmd/build/run_test.go
+++ b/pkg/shp/cmd/build/run_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	shpfake "github.com/shipwright-io/build/pkg/client/clientset/versioned/fake"
 	"github.com/shipwright-io/cli/pkg/shp/flags"
 	"github.com/shipwright-io/cli/pkg/shp/params"
@@ -98,8 +98,8 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
 				Labels: map[string]string{
-					buildv1alpha1.LabelBuild:    name,
-					buildv1alpha1.LabelBuildRun: name,
+					buildv1beta1.LabelBuild:    name,
+					buildv1beta1.LabelBuildRun: name,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -108,7 +108,7 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 				}},
 			},
 		}
-		br := &buildv1alpha1.BuildRun{
+		br := &buildv1beta1.BuildRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
@@ -153,26 +153,26 @@ func TestStartBuildRunFollowLog(t *testing.T) {
 
 		switch {
 		case test.cancelled:
-			br.Spec.State = buildv1alpha1.BuildRunRequestedStatePtr(buildv1alpha1.BuildRunStateCancel)
-			br.Status.Conditions = []buildv1alpha1.Condition{
+			br.Spec.State = buildv1beta1.BuildRunRequestedStatePtr(buildv1beta1.BuildRunStateCancel)
+			br.Status.Conditions = []buildv1beta1.Condition{
 				{
-					Type:   buildv1alpha1.Succeeded,
+					Type:   buildv1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.brDeleted:
 			br.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []buildv1alpha1.Condition{
+			br.Status.Conditions = []buildv1beta1.Condition{
 				{
-					Type:   buildv1alpha1.Succeeded,
+					Type:   buildv1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.podDeleted:
 			pod.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []buildv1alpha1.Condition{
+			br.Status.Conditions = []buildv1beta1.Condition{
 				{
-					Type:   buildv1alpha1.Succeeded,
+					Type:   buildv1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}

--- a/pkg/shp/cmd/buildrun/cancel.go
+++ b/pkg/shp/cmd/buildrun/cancel.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 )
@@ -56,8 +56,8 @@ func (c *CancelCommand) Run(params *params.Params, ioStreams *genericclioptions.
 		return err
 	}
 
-	var br *buildv1alpha1.BuildRun
-	if br, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Get(c.cmd.Context(), c.name, metav1.GetOptions{}); err != nil {
+	var br *buildv1beta1.BuildRun
+	if br, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Get(c.cmd.Context(), c.name, metav1.GetOptions{}); err != nil {
 		return fmt.Errorf("failed to retrieve BuildRun %s: %s", c.name, err.Error())
 	}
 	if br.IsDone() {
@@ -72,13 +72,13 @@ func (c *CancelCommand) Run(params *params.Params, ioStreams *genericclioptions.
 	payload := []patchStringValue{{
 		Op:    "replace",
 		Path:  "/spec/state",
-		Value: buildv1alpha1.BuildRunStateCancel,
+		Value: buildv1beta1.BuildRunStateCancel,
 	}}
 	var data []byte
 	if data, err = json.Marshal(payload); err != nil {
 		return err
 	}
-	if _, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Patch(c.Cmd().Context(), c.name, types.JSONPatchType, data, metav1.PatchOptions{}); err != nil {
+	if _, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Patch(c.Cmd().Context(), c.name, types.JSONPatchType, data, metav1.PatchOptions{}); err != nil {
 		return err
 	}
 

--- a/pkg/shp/cmd/buildrun/cancel_test.go
+++ b/pkg/shp/cmd/buildrun/cancel_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/build/pkg/client/clientset/versioned/fake"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 )
 
 func TestCancelBuildRun(t *testing.T) {
 	tests := map[string]struct {
-		br              *v1alpha1.BuildRun
+		br              *v1beta1.BuildRun
 		expectCancelSet bool
 		expectErr       bool
 	}{
@@ -26,15 +26,15 @@ func TestCancelBuildRun(t *testing.T) {
 			expectErr: true,
 		},
 		"completed": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "completed",
 					Namespace: metav1.NamespaceDefault,
 				},
-				Status: v1alpha1.BuildRunStatus{
-					Conditions: v1alpha1.Conditions{
+				Status: v1beta1.BuildRunStatus{
+					Conditions: v1beta1.Conditions{
 						{
-							Type:   v1alpha1.Succeeded,
+							Type:   v1beta1.Succeeded,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -42,15 +42,15 @@ func TestCancelBuildRun(t *testing.T) {
 			expectErr: true,
 		},
 		"failed": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "failed",
 					Namespace: metav1.NamespaceDefault,
 				},
-				Status: v1alpha1.BuildRunStatus{
-					Conditions: v1alpha1.Conditions{
+				Status: v1beta1.BuildRunStatus{
+					Conditions: v1beta1.Conditions{
 						{
-							Type:   v1alpha1.Succeeded,
+							Type:   v1beta1.Succeeded,
 							Status: corev1.ConditionFalse,
 						},
 					},
@@ -58,7 +58,7 @@ func TestCancelBuildRun(t *testing.T) {
 			expectErr: true,
 		},
 		"condition-missing": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "failed",
 					Namespace: metav1.NamespaceDefault,
@@ -67,15 +67,15 @@ func TestCancelBuildRun(t *testing.T) {
 			expectCancelSet: true,
 		},
 		"in-progress": {
-			br: &v1alpha1.BuildRun{
+			br: &v1beta1.BuildRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "failed",
 					Namespace: metav1.NamespaceDefault,
 				},
-				Status: v1alpha1.BuildRunStatus{
-					Conditions: v1alpha1.Conditions{
+				Status: v1beta1.BuildRunStatus{
+					Conditions: v1beta1.Conditions{
 						{
-							Type:   v1alpha1.Succeeded,
+							Type:   v1beta1.Succeeded,
 							Status: corev1.ConditionUnknown,
 						},
 					},
@@ -112,7 +112,7 @@ func TestCancelBuildRun(t *testing.T) {
 			continue
 		}
 
-		buildRun, _ := clientset.ShipwrightV1alpha1().BuildRuns(param.Namespace()).Get(context.Background(), test.br.Name, metav1.GetOptions{})
+		buildRun, _ := clientset.ShipwrightV1beta1().BuildRuns(param.Namespace()).Get(context.Background(), test.br.Name, metav1.GetOptions{})
 
 		if test.expectCancelSet && !buildRun.IsCanceled() {
 			t.Errorf("%s: cancel not set", testName)

--- a/pkg/shp/cmd/buildrun/create.go
+++ b/pkg/shp/cmd/buildrun/create.go
@@ -3,7 +3,7 @@ package buildrun
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,8 +18,8 @@ import (
 type CreateCommand struct {
 	cmd *cobra.Command // cobra command instance
 
-	name         string                      // buildrun name
-	buildRunSpec *buildv1alpha1.BuildRunSpec // stores command-line flags
+	name         string                     // buildrun name
+	buildRunSpec *buildv1beta1.BuildRunSpec // stores command-line flags
 }
 
 const buildRunCreateLongDesc = `
@@ -55,7 +55,7 @@ func (c *CreateCommand) Validate() error {
 
 // Run executes the creation of BuildRun object.
 func (c *CreateCommand) Run(params *params.Params, ioStreams *genericclioptions.IOStreams) error {
-	br := &buildv1alpha1.BuildRun{
+	br := &buildv1beta1.BuildRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.name,
 		},
@@ -68,10 +68,12 @@ func (c *CreateCommand) Run(params *params.Params, ioStreams *genericclioptions.
 	if err != nil {
 		return err
 	}
-	if _, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Create(c.cmd.Context(), br, metav1.CreateOptions{}); err != nil {
+	if _, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Create(c.cmd.Context(), br, metav1.CreateOptions{}); err != nil {
 		return err
 	}
-	fmt.Fprintf(ioStreams.Out, "BuildRun created %q for Build %q\n", c.name, br.Spec.BuildRef.Name)
+
+	// Cli doesn't allow standalone buildruns, so it will always refer an existing build.
+	fmt.Fprintf(ioStreams.Out, "BuildRun created %q for Build %q\n", c.name, *br.Spec.Build.Name)
 	return nil
 }
 

--- a/pkg/shp/cmd/buildrun/delete.go
+++ b/pkg/shp/cmd/buildrun/delete.go
@@ -53,7 +53,7 @@ func (c *DeleteCommand) Run(params *params.Params, ioStreams *genericclioptions.
 		return err
 	}
 
-	if err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), c.name, metav1.DeleteOptions{}); err != nil {
+	if err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).Delete(c.cmd.Context(), c.name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/pkg/shp/cmd/buildrun/list.go
+++ b/pkg/shp/cmd/buildrun/list.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	"github.com/shipwright-io/cli/pkg/shp/cmd/runner"
 	"github.com/shipwright-io/cli/pkg/shp/params"
@@ -81,8 +81,8 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 		return err
 	}
 
-	var brs *buildv1alpha1.BuildRunList
-	if brs, err = clientset.ShipwrightV1alpha1().BuildRuns(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
+	var brs *buildv1beta1.BuildRunList
+	if brs, err = clientset.ShipwrightV1beta1().BuildRuns(params.Namespace()).List(c.cmd.Context(), metav1.ListOptions{}); err != nil {
 		return err
 	}
 	if len(brs.Items) == 0 {
@@ -98,7 +98,7 @@ func (c *ListCommand) Run(params *params.Params, io *genericclioptions.IOStreams
 		name := br.Name
 		status := string(metav1.ConditionUnknown)
 		for _, condition := range br.Status.Conditions {
-			if condition.Type == buildv1alpha1.Succeeded {
+			if condition.Type == buildv1beta1.Succeeded {
 				status = condition.Reason
 				break
 			}

--- a/pkg/shp/cmd/buildrun/logs.go
+++ b/pkg/shp/cmd/buildrun/logs.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
 
 	"github.com/shipwright-io/cli/pkg/shp/cmd/follower"
@@ -78,7 +78,7 @@ func (c *LogsCommand) Run(params *params.Params, ioStreams *genericclioptions.IO
 	}
 
 	lo := v1.ListOptions{
-		LabelSelector: fmt.Sprintf("%v=%v", buildv1alpha1.LabelBuildRun, c.name),
+		LabelSelector: fmt.Sprintf("%v=%v", buildv1beta1.LabelBuildRun, c.name),
 	}
 
 	// first see if pod is already done; if so, even if we have follow == true, just do the normal path;

--- a/pkg/shp/cmd/buildrun/logs_test.go
+++ b/pkg/shp/cmd/buildrun/logs_test.go
@@ -10,7 +10,7 @@ import (
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	fakekubetesting "k8s.io/client-go/testing"
 
-	"github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	"github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/shipwright-io/cli/pkg/shp/params"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +27,7 @@ func TestStreamBuildLogs(t *testing.T) {
 	pod.Name = name
 	pod.Namespace = metav1.NamespaceDefault
 	pod.Labels = map[string]string{
-		v1alpha1.LabelBuildRun: name,
+		v1beta1.LabelBuildRun: name,
 	}
 	pod.Spec.Containers = []corev1.Container{
 		{
@@ -132,8 +132,8 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
 				Labels: map[string]string{
-					v1alpha1.LabelBuild:    name,
-					v1alpha1.LabelBuildRun: name,
+					v1beta1.LabelBuild:    name,
+					v1beta1.LabelBuildRun: name,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -142,7 +142,7 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 				}},
 			},
 		}
-		br := &v1alpha1.BuildRun{
+		br := &v1beta1.BuildRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: metav1.NamespaceDefault,
 				Name:      name,
@@ -186,26 +186,26 @@ func TestStreamBuildRunFollowLogs(t *testing.T) {
 
 		switch {
 		case test.cancelled:
-			br.Spec.State = v1alpha1.BuildRunRequestedStatePtr(v1alpha1.BuildRunStateCancel)
-			br.Status.Conditions = []v1alpha1.Condition{
+			br.Spec.State = v1beta1.BuildRunRequestedStatePtr(v1beta1.BuildRunStateCancel)
+			br.Status.Conditions = []v1beta1.Condition{
 				{
-					Type:   v1alpha1.Succeeded,
+					Type:   v1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.brDeleted:
 			br.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []v1alpha1.Condition{
+			br.Status.Conditions = []v1beta1.Condition{
 				{
-					Type:   v1alpha1.Succeeded,
+					Type:   v1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}
 		case test.podDeleted:
 			pod.DeletionTimestamp = &metav1.Time{}
-			br.Status.Conditions = []v1alpha1.Condition{
+			br.Status.Conditions = []v1beta1.Condition{
 				{
-					Type:   v1alpha1.Succeeded,
+					Type:   v1beta1.Succeeded,
 					Status: corev1.ConditionFalse,
 				},
 			}

--- a/pkg/shp/flags/build.go
+++ b/pkg/shp/flags/build.go
@@ -44,6 +44,7 @@ func BuildSpecFromFlags(flags *pflag.FlagSet) (*buildv1beta1.BuildSpec, *string,
 			TTLAfterFailed:    &metav1.Duration{},
 			TTLAfterSucceeded: &metav1.Duration{},
 		},
+		NodeSelector: map[string]string{},
 	}
 
 	sourceFlags(flags, spec.Source)
@@ -55,7 +56,7 @@ func BuildSpecFromFlags(flags *pflag.FlagSet) (*buildv1beta1.BuildSpec, *string,
 	imageLabelsFlags(flags, spec.Output.Labels)
 	imageAnnotationsFlags(flags, spec.Output.Annotations)
 	buildRetentionFlags(flags, spec.Retention)
-
+	buildNodeSelectorFlags(flags, spec.NodeSelector)
 	var dockerfile, builderImage string
 	dockerfileFlags(flags, &dockerfile)
 	builderImageFlag(flags, &builderImage)

--- a/pkg/shp/flags/build_test.go
+++ b/pkg/shp/flags/build_test.go
@@ -55,6 +55,7 @@ func TestBuildSpecFromFlags(t *testing.T) {
 				Duration: 30 * time.Minute,
 			},
 		},
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
 	}
 
 	cmd := &cobra.Command{}
@@ -113,6 +114,13 @@ func TestBuildSpecFromFlags(t *testing.T) {
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(expected.Output).To(o.Equal(spec.Output), "spec.output")
+	})
+
+	t.Run(".spec.nodeSelector", func(_ *testing.T) {
+		err := flags.Set(NodeSelectorFlag, "kubernetes.io/hostname=worker-1")
+		g.Expect(err).To(o.BeNil())
+		// g.Expect(expected.NodeSelector).To(o.HaveKeyWithValue("kubernetes.io/hostname",spec.NodeSelector["kubernetes.io/hostname"]), ".spec.nodeSelector")
+		g.Expect(expected.NodeSelector).To(o.Equal(spec.NodeSelector), ".spec.nodeSelector")
 	})
 
 	t.Run(".spec.timeout", func(_ *testing.T) {

--- a/pkg/shp/flags/buildrun.go
+++ b/pkg/shp/flags/buildrun.go
@@ -28,6 +28,7 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1beta1.BuildRunSpec {
 			TTLAfterFailed:    &metav1.Duration{},
 			TTLAfterSucceeded: &metav1.Duration{},
 		},
+		NodeSelector: map[string]string{},
 	}
 
 	buildRefFlags(flags, &spec.Build)
@@ -39,7 +40,7 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1beta1.BuildRunSpec {
 	imageLabelsFlags(flags, spec.Output.Labels)
 	imageAnnotationsFlags(flags, spec.Output.Annotations)
 	buildRunRetentionFlags(flags, spec.Retention)
-
+	buildNodeSelectorFlags(flags, spec.NodeSelector)
 	return spec
 }
 

--- a/pkg/shp/flags/buildrun.go
+++ b/pkg/shp/flags/buildrun.go
@@ -1,7 +1,7 @@
 package flags
 
 import (
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/pflag"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,30 +10,27 @@ import (
 )
 
 // BuildRunSpecFromFlags creates a BuildRun spec from command-line flags.
-func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildRunSpec {
-	spec := &buildv1alpha1.BuildRunSpec{
-		BuildRef: &buildv1alpha1.BuildRef{
-			APIVersion: ptr.To(""),
+func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1beta1.BuildRunSpec {
+	spec := &buildv1beta1.BuildRunSpec{
+		Build: buildv1beta1.ReferencedBuild{
+			Name: ptr.To(""),
 		},
-		ServiceAccount: &buildv1alpha1.ServiceAccount{
-			Name:     ptr.To(""),
-			Generate: ptr.To(false),
-		},
-		Timeout: &metav1.Duration{},
-		Output: &buildv1alpha1.Image{
-			Credentials: &corev1.LocalObjectReference{},
+		ServiceAccount: ptr.To(""),
+		Timeout:        &metav1.Duration{},
+		Output: &buildv1beta1.Image{
+			PushSecret:  ptr.To(""),
 			Insecure:    ptr.To(false),
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
 		Env: []corev1.EnvVar{},
-		Retention: &buildv1alpha1.BuildRunRetention{
+		Retention: &buildv1beta1.BuildRunRetention{
 			TTLAfterFailed:    &metav1.Duration{},
 			TTLAfterSucceeded: &metav1.Duration{},
 		},
 	}
 
-	buildRefFlags(flags, spec.BuildRef)
+	buildRefFlags(flags, &spec.Build)
 	serviceAccountFlags(flags, spec.ServiceAccount)
 	timeoutFlags(flags, spec.Timeout)
 	imageFlags(flags, "output", spec.Output)
@@ -47,33 +44,24 @@ func BuildRunSpecFromFlags(flags *pflag.FlagSet) *buildv1alpha1.BuildRunSpec {
 }
 
 // SanitizeBuildRunSpec checks for empty inner data structures and replaces them with nil.
-func SanitizeBuildRunSpec(br *buildv1alpha1.BuildRunSpec) {
+func SanitizeBuildRunSpec(br *buildv1beta1.BuildRunSpec) {
 	if br == nil {
 		return
 	}
-	if br.BuildRef != nil {
-		if br.BuildRef.APIVersion != nil && *br.BuildRef.APIVersion == "" {
-			br.BuildRef.APIVersion = nil
-		}
-
-		if br.BuildRef.Name == "" && br.BuildRef.APIVersion == nil {
-			br.BuildRef = nil
-		}
+	if br.Build.Name != nil && *br.Build.Name == "" {
+		br.Build.Name = nil
 	}
-	if br.ServiceAccount != nil {
-		if (br.ServiceAccount.Name == nil || *br.ServiceAccount.Name == "") &&
-			(br.ServiceAccount.Generate == nil || !*br.ServiceAccount.Generate) {
-			br.ServiceAccount = nil
-		}
+	if br.ServiceAccount != nil && *br.ServiceAccount == "" {
+		br.ServiceAccount = nil
 	}
 	if br.Output != nil {
-		if br.Output.Credentials != nil && br.Output.Credentials.Name == "" {
-			br.Output.Credentials = nil
+		if br.Output.PushSecret != nil && *br.Output.PushSecret == "" {
+			br.Output.PushSecret = nil
 		}
 		if br.Output.Insecure != nil && !*br.Output.Insecure {
 			br.Output.Insecure = nil
 		}
-		if br.Output.Image == "" && br.Output.Credentials == nil {
+		if br.Output.Image == "" && br.Output.PushSecret == nil {
 			br.Output = nil
 		}
 	}

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -38,6 +38,7 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 				Duration: 30 * time.Minute,
 			},
 		},
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
 	}
 
 	cmd := &cobra.Command{}
@@ -73,6 +74,13 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(*expected.Output).To(o.Equal(*spec.Output), "spec.output")
+	})
+
+	t.Run(".spec.nodeSelector", func(_ *testing.T) {
+		err := flags.Set(NodeSelectorFlag, "kubernetes.io/hostname=worker-1")
+		g.Expect(err).To(o.BeNil())
+		// g.Expect(expected.NodeSelector).To(o.HaveKeyWithValue("kubernetes.io/hostname",spec.NodeSelector["kubernetes.io/hostname"]), ".spec.nodeSelector")
+		g.Expect(expected.NodeSelector).To(o.Equal(spec.NodeSelector), ".spec.nodeSelector")
 	})
 
 	t.Run(".spec.retention.ttlAfterFailed", func(_ *testing.T) {

--- a/pkg/shp/flags/buildrun_test.go
+++ b/pkg/shp/flags/buildrun_test.go
@@ -1,14 +1,12 @@
 package flags
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
 	o "github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -17,26 +15,22 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 	g := o.NewWithT(t)
 
 	str := "something-random"
-	expected := &buildv1alpha1.BuildRunSpec{
-		BuildRef: &buildv1alpha1.BuildRef{
-			Name:       str,
-			APIVersion: ptr.To(""),
+	expected := &buildv1beta1.BuildRunSpec{
+		Build: buildv1beta1.ReferencedBuild{
+			Name: &str,
 		},
-		ServiceAccount: &buildv1alpha1.ServiceAccount{
-			Name:     &str,
-			Generate: ptr.To(false),
-		},
+		ServiceAccount: &str,
 		Timeout: &metav1.Duration{
 			Duration: 1 * time.Second,
 		},
-		Output: &buildv1alpha1.Image{
-			Credentials: &corev1.LocalObjectReference{Name: "name"},
+		Output: &buildv1beta1.Image{
+			PushSecret:  ptr.To("name"),
 			Image:       str,
 			Insecure:    ptr.To(false),
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
-		Retention: &buildv1alpha1.BuildRunRetention{
+		Retention: &buildv1beta1.BuildRunRetention{
 			TTLAfterFailed: &metav1.Duration{
 				Duration: 48 * time.Hour,
 			},
@@ -51,17 +45,14 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 	spec := BuildRunSpecFromFlags(flags)
 
 	t.Run(".spec.buildRef", func(_ *testing.T) {
-		err := flags.Set(BuildrefNameFlag, expected.BuildRef.Name)
+		err := flags.Set(BuildrefNameFlag, *expected.Build.Name)
 		g.Expect(err).To(o.BeNil())
 
-		g.Expect(*expected.BuildRef).To(o.Equal(*spec.BuildRef), "spec.buildRef")
+		g.Expect(expected.Build).To(o.Equal(spec.Build), "spec.buildRef")
 	})
 
 	t.Run(".spec.serviceAccount", func(_ *testing.T) {
-		err := flags.Set(ServiceAccountNameFlag, *expected.ServiceAccount.Name)
-		g.Expect(err).To(o.BeNil())
-
-		err = flags.Set(ServiceAccountGenerateFlag, strconv.FormatBool(*expected.ServiceAccount.Generate))
+		err := flags.Set(ServiceAccountNameFlag, *expected.ServiceAccount)
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(*expected.ServiceAccount).To(o.Equal(*spec.ServiceAccount), "spec.serviceAccount")
@@ -78,7 +69,7 @@ func TestBuildRunSpecFromFlags(t *testing.T) {
 		err := flags.Set(OutputImageFlag, expected.Output.Image)
 		g.Expect(err).To(o.BeNil())
 
-		err = flags.Set(OutputCredentialsSecretFlag, expected.Output.Credentials.Name)
+		err = flags.Set(OutputCredentialsSecretFlag, *expected.Output.PushSecret)
 		g.Expect(err).To(o.BeNil())
 
 		g.Expect(*expected.Output).To(o.Equal(*spec.Output), "spec.output")
@@ -103,46 +94,46 @@ func TestSanitizeBuildRunSpec(t *testing.T) {
 	g := o.NewWithT(t)
 
 	name := "name"
-	completeBuildRunSpec := buildv1alpha1.BuildRunSpec{
-		ServiceAccount: &buildv1alpha1.ServiceAccount{Name: &name},
-		Output: &buildv1alpha1.Image{
-			Credentials: &corev1.LocalObjectReference{Name: "name"},
-			Image:       "image",
+	completeBuildRunSpec := buildv1beta1.BuildRunSpec{
+		ServiceAccount: &name,
+		Output: &buildv1beta1.Image{
+			PushSecret: ptr.To("name"),
+			Image:      "image",
 		},
 	}
 
 	testCases := []struct {
 		name string
-		in   buildv1alpha1.BuildRunSpec
-		out  buildv1alpha1.BuildRunSpec
+		in   buildv1beta1.BuildRunSpec
+		out  buildv1beta1.BuildRunSpec
 	}{{
 		name: "all empty should stay empty",
-		in:   buildv1alpha1.BuildRunSpec{},
-		out:  buildv1alpha1.BuildRunSpec{},
+		in:   buildv1beta1.BuildRunSpec{},
+		out:  buildv1beta1.BuildRunSpec{},
 	}, {
 		name: "should clean-up service-account",
-		in:   buildv1alpha1.BuildRunSpec{ServiceAccount: &buildv1alpha1.ServiceAccount{}},
-		out:  buildv1alpha1.BuildRunSpec{},
+		in:   buildv1beta1.BuildRunSpec{ServiceAccount: ptr.To("")},
+		out:  buildv1beta1.BuildRunSpec{},
 	}, {
 		name: "should clean-up output",
-		in:   buildv1alpha1.BuildRunSpec{Output: &buildv1alpha1.Image{}},
-		out:  buildv1alpha1.BuildRunSpec{},
+		in:   buildv1beta1.BuildRunSpec{Output: &buildv1beta1.Image{}},
+		out:  buildv1beta1.BuildRunSpec{},
 	}, {
 		name: "should not clean-up complete objects",
 		in:   completeBuildRunSpec,
 		out:  completeBuildRunSpec,
 	}, {
 		name: "should clean-up 0s duration",
-		in: buildv1alpha1.BuildRunSpec{Timeout: &metav1.Duration{
+		in: buildv1beta1.BuildRunSpec{Timeout: &metav1.Duration{
 			Duration: time.Duration(0),
 		}},
-		out: buildv1alpha1.BuildRunSpec{Timeout: nil},
+		out: buildv1beta1.BuildRunSpec{Timeout: nil},
 	}, {
 		name: "should clean-up an empty retention",
-		in: buildv1alpha1.BuildRunSpec{
-			Retention: &buildv1alpha1.BuildRunRetention{},
+		in: buildv1beta1.BuildRunSpec{
+			Retention: &buildv1beta1.BuildRunRetention{},
 		},
-		out: buildv1alpha1.BuildRunSpec{},
+		out: buildv1beta1.BuildRunSpec{},
 	}}
 
 	for _, tt := range testCases {

--- a/pkg/shp/flags/core_envvar_value_test.go
+++ b/pkg/shp/flags/core_envvar_value_test.go
@@ -3,7 +3,7 @@ package flags
 import (
 	"testing"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 
 	o "github.com/onsi/gomega"
@@ -12,7 +12,7 @@ import (
 func TestCoreEnvVarSliceValue(t *testing.T) {
 	g := o.NewWithT(t)
 
-	spec := &buildv1alpha1.BuildSpec{Env: []corev1.EnvVar{}}
+	spec := &buildv1beta1.BuildSpec{Env: []corev1.EnvVar{}}
 	c := NewCoreEnvVarArrayValue(&spec.Env)
 
 	// expect error when key-value is not split by equal sign

--- a/pkg/shp/flags/flags.go
+++ b/pkg/shp/flags/flags.go
@@ -64,6 +64,8 @@ const (
 	RetentionTTLAfterFailedFlag = "retention-ttl-after-failed"
 	// RetentionTTLAfterSucceededFlag command-line flag.
 	RetentionTTLAfterSucceededFlag = "retention-ttl-after-succeeded"
+	// NodeSelectorFlag command-line flag.
+	NodeSelectorFlag = "node-selector"
 )
 
 // sourceFlags flags for ".spec.source"
@@ -257,6 +259,11 @@ func serviceAccountFlags(flags *pflag.FlagSet, sa *string) {
 	)
 	flags.MarkDeprecated("sa-generate", fmt.Sprintf("this flag has no effect, please use --%s for service account", ServiceAccountNameFlag))
 
+}
+
+// buildNodeSelectorFlags registers flags for adding BuildSpec.NodeSelector
+func buildNodeSelectorFlags(flags *pflag.FlagSet, nodeSelectorLabels map[string]string) {
+	flags.Var(NewMapValue(nodeSelectorLabels), NodeSelectorFlag, "set of key-value pairs that correspond to labels of a node to match")
 }
 
 // envFlags registers flags for adding corev1.EnvVars.

--- a/pkg/shp/flags/map_value_test.go
+++ b/pkg/shp/flags/map_value_test.go
@@ -3,7 +3,7 @@ package flags
 import (
 	"testing"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	o "github.com/onsi/gomega"
 )
@@ -11,7 +11,7 @@ import (
 func TestNewMapValue(t *testing.T) {
 	g := o.NewWithT(t)
 
-	spec := &buildv1alpha1.BuildSpec{Output: buildv1alpha1.Image{
+	spec := &buildv1beta1.BuildSpec{Output: buildv1beta1.Image{
 		Labels: map[string]string{},
 	}}
 	c := NewMapValue(spec.Output.Labels)

--- a/pkg/shp/flags/param_value.go
+++ b/pkg/shp/flags/param_value.go
@@ -3,13 +3,13 @@ package flags
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 // ParamArrayValue implements pflag.Value interface, in order to store ParamValue key-value
 // pairs used on Shipwright's BuildSpec.
 type ParamArrayValue struct {
-	params *[]buildv1alpha1.ParamValue // pointer to the slice of ParamValue
+	params *[]buildv1beta1.ParamValue // pointer to the slice of ParamValue
 }
 
 // String prints out the string representation of the slice of EnvVar objects.
@@ -33,7 +33,7 @@ func (p *ParamArrayValue) Set(value string) error {
 			return fmt.Errorf("environment variable '%s' is already set", k)
 		}
 	}
-	*p.params = append(*p.params, buildv1alpha1.ParamValue{Name: k, SingleValue: &buildv1alpha1.SingleValue{Value: &v}})
+	*p.params = append(*p.params, buildv1beta1.ParamValue{Name: k, SingleValue: &buildv1beta1.SingleValue{Value: &v}})
 	return nil
 }
 
@@ -45,6 +45,6 @@ func (p *ParamArrayValue) Type() string {
 }
 
 // NewCoreEnvVarArrayValue instantiate a ParamValSliceValue sharing the EnvVar pointer.
-func NewParamArrayValue(params *[]buildv1alpha1.ParamValue) *ParamArrayValue {
+func NewParamArrayValue(params *[]buildv1beta1.ParamValue) *ParamArrayValue {
 	return &ParamArrayValue{params: params}
 }

--- a/pkg/shp/flags/param_value_test.go
+++ b/pkg/shp/flags/param_value_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 func TestNewParamArrayValue(t *testing.T) {
@@ -42,7 +42,7 @@ func TestNewParamArrayValue(t *testing.T) {
 	}
 	for tName, tCase := range testCases {
 		t.Run(tName, func(_ *testing.T) {
-			buildSpec := buildv1alpha1.BuildSpec{}
+			buildSpec := buildv1beta1.BuildSpec{}
 			buildParamVal := NewParamArrayValue(&buildSpec.ParamValues)
 
 			err := buildParamVal.Set(tCase.paramPassed)

--- a/pkg/shp/flags/prune_option_value.go
+++ b/pkg/shp/flags/prune_option_value.go
@@ -3,28 +3,28 @@ package flags
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 // pruneOptionFlag serves as an adapter to make the Build spec source bundle
 // container prune option to be used as a command-line flag (pflag.Value).
 type pruneOptionFlag struct {
-	ref *buildv1alpha1.PruneOption
+	ref *buildv1beta1.PruneOption
 }
 
 // Set translates the provided input string into one of the supported prune
 // options, or fails with an error in cases of an unsupported value
 func (p pruneOptionFlag) Set(val string) error {
-	var pruneOption = buildv1alpha1.PruneOption(val)
+	var pruneOption = buildv1beta1.PruneOption(val)
 	switch pruneOption {
-	case buildv1alpha1.PruneNever, buildv1alpha1.PruneAfterPull:
+	case buildv1beta1.PruneNever, buildv1beta1.PruneAfterPull:
 		*p.ref = pruneOption
 		return nil
 
 	default:
 		return fmt.Errorf("supported values are %s, or %s",
-			buildv1alpha1.PruneNever,
-			buildv1alpha1.PruneAfterPull,
+			buildv1beta1.PruneNever,
+			buildv1beta1.PruneAfterPull,
 		)
 	}
 }
@@ -33,7 +33,7 @@ func (p pruneOptionFlag) Set(val string) error {
 // spec source container bundle prune default of `Never` in case it is not set
 func (p pruneOptionFlag) String() string {
 	if p.ref == nil {
-		return string(buildv1alpha1.PruneNever)
+		return string(buildv1beta1.PruneNever)
 	}
 
 	return string(*p.ref)

--- a/pkg/shp/flags/prune_option_value_test.go
+++ b/pkg/shp/flags/prune_option_value_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	o "github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 func TestSourcePruneOption(t *testing.T) {
@@ -12,16 +12,16 @@ func TestSourcePruneOption(t *testing.T) {
 
 	// Check for type and defaults
 	g.Expect(pruneOptionFlag{}.Type()).To(o.Equal("pruneOption"))
-	g.Expect(pruneOptionFlag{}.String()).To(o.Equal(string(buildv1alpha1.PruneNever)))
+	g.Expect(pruneOptionFlag{}.String()).To(o.Equal(string(buildv1beta1.PruneNever)))
 
-	var obj buildv1alpha1.PruneOption
+	var obj buildv1beta1.PruneOption
 	v := pruneOptionFlag{ref: &obj}
 
 	// Check the supported values
-	g.Expect(v.Set(string(buildv1alpha1.PruneNever))).Should(o.Succeed())
-	g.Expect(v.String()).To(o.Equal(string(buildv1alpha1.PruneNever)))
-	g.Expect(v.Set(string(buildv1alpha1.PruneAfterPull))).Should(o.Succeed())
-	g.Expect(v.String()).To(o.Equal(string(buildv1alpha1.PruneAfterPull)))
+	g.Expect(v.Set(string(buildv1beta1.PruneNever))).Should(o.Succeed())
+	g.Expect(v.String()).To(o.Equal(string(buildv1beta1.PruneNever)))
+	g.Expect(v.Set(string(buildv1beta1.PruneAfterPull))).Should(o.Succeed())
+	g.Expect(v.String()).To(o.Equal(string(buildv1beta1.PruneAfterPull)))
 
 	// Check that invalid values fail with the flag
 	g.Expect(v.Set("invalid")).ToNot(o.Succeed())

--- a/pkg/shp/flags/strategy_kind_value.go
+++ b/pkg/shp/flags/strategy_kind_value.go
@@ -3,13 +3,13 @@ package flags
 import (
 	"fmt"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 // StrategyKindValue implements pflag.Value interface, to represent Shipwright's BuildStrategyKind as
 // a string command-line in an cobra.Command instance.
 type StrategyKindValue struct {
-	kindPtr *buildv1alpha1.BuildStrategyKind
+	kindPtr *buildv1beta1.BuildStrategyKind
 }
 
 // String shows the value as string.
@@ -22,9 +22,9 @@ func (s *StrategyKindValue) String() string {
 
 // Set set the informed string as BuildStrategyKind by casting.
 func (s *StrategyKindValue) Set(value string) error {
-	kind := buildv1alpha1.BuildStrategyKind(value)
-	if kind != buildv1alpha1.NamespacedBuildStrategyKind &&
-		kind != buildv1alpha1.ClusterBuildStrategyKind {
+	kind := buildv1beta1.BuildStrategyKind(value)
+	if kind != buildv1beta1.NamespacedBuildStrategyKind &&
+		kind != buildv1beta1.ClusterBuildStrategyKind {
 		return fmt.Errorf("'%s' is an invalid BuildStrategyKind", value)
 	}
 	*s.kindPtr = kind
@@ -37,6 +37,6 @@ func (s *StrategyKindValue) Type() string {
 }
 
 // NewStrategyKindValue creates a new instance of StrategyKindValue sharing an existing reference.
-func NewStrategyKindValue(kindPtr *buildv1alpha1.BuildStrategyKind) *StrategyKindValue {
+func NewStrategyKindValue(kindPtr *buildv1beta1.BuildStrategyKind) *StrategyKindValue {
 	return &StrategyKindValue{kindPtr: kindPtr}
 }

--- a/pkg/shp/flags/strategy_kind_value_test.go
+++ b/pkg/shp/flags/strategy_kind_value_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	o "github.com/onsi/gomega"
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 )
 
 func TestStrategyKindValue(t *testing.T) {
 	g := o.NewWithT(t)
 
-	buildStrategyKind := buildv1alpha1.ClusterBuildStrategyKind
+	buildStrategyKind := buildv1beta1.ClusterBuildStrategyKind
 	v := NewStrategyKindValue(&buildStrategyKind)
 
-	expected := buildv1alpha1.NamespacedBuildStrategyKind
+	expected := buildv1beta1.NamespacedBuildStrategyKind
 
 	err := v.Set(string(expected))
 	g.Expect(err).To(o.BeNil())

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -51,7 +51,7 @@ teardown() {
 	buildrun_name=$(random_name)
 
 	# ensure that shp build create does not give an error when a build_name is specified
-	run shp build create ${build_name} --source-url=url --output-image=image
+	run shp build create ${build_name} --source-git-url=url --output-image=image
 	assert_success
 
 	# ensure that shp buildrun create does not give an error when a buildrun_name is specified
@@ -63,14 +63,14 @@ teardown() {
 	# ensure that shp command doesn't log the api calls by default
 	run shp build list
 	assert_success
-	refute_line --regexp "GET .*/apis/shipwright.io/v1alpha1/namespaces/"
+	refute_line --regexp "GET .*/apis/shipwright.io/v1beta1/namespaces/"
 	refute_line --partial "Response Headers"
 	refute_line --partial "Response Body"
 
 	# ensure that shp command supports -v loglevel flag.
 	run shp -v=10 build list
 	assert_success
-	assert_line --regexp "GET .*/apis/shipwright.io/v1alpha1/namespaces/"
+	assert_line --regexp "GET .*/apis/shipwright.io/v1beta1/namespaces/"
 	assert_line --partial "Response Headers"
 	assert_line --partial "Response Body"
 }

--- a/test/e2e/envvars.bats
+++ b/test/e2e/envvars.bats
@@ -19,7 +19,7 @@ teardown() {
 	buildrun_name=$(random_name)
 
 	# create a Build with two environment variables
-	run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image --env=VAR_1=build-value-1 --env=VAR_2=build-value-2
+	run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-image --env=VAR_1=build-value-1 --env=VAR_2=build-value-2
 	assert_success
 
 	# ensure that the build was successfully created

--- a/test/e2e/log-follow--follow.bats
+++ b/test/e2e/log-follow--follow.bats
@@ -21,7 +21,7 @@ teardown() {
 
     # creating a golang based build
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image}
     assert_success

--- a/test/e2e/log-follow-F.bats
+++ b/test/e2e/log-follow-F.bats
@@ -21,7 +21,7 @@ teardown() {
 
     # create a Build with two environment variables
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image}
     assert_success

--- a/test/e2e/node-selector.bats
+++ b/test/e2e/node-selector.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+
+source test/e2e/helpers.sh
+
+setup() {
+	load 'bats/support/load'
+	load 'bats/assert/load'
+	load 'bats/file/load'
+}
+
+teardown() {
+	run kubectl delete builds.shipwright.io --all
+	run kubectl delete buildruns.shipwright.io --all
+}
+
+@test "shp build create --node-selector single label" {
+    # generate random names for our build
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-fake-image --node-selector="kubernetes.io/hostname=node-1"
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get builds.shipwright.io/${build_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output '{"kubernetes.io/hostname":"node-1"}'
+}
+
+@test "shp build create --node-selector multiple labels" {
+    # generate random names for our build
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-fake-image --node-selector="kubernetes.io/hostname=node-1" --node-selector="kubernetes.io/os=linux" 
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get builds.shipwright.io/${build_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output --partial '"kubernetes.io/hostname":"node-1"'
+    assert_output --partial '"kubernetes.io/os":"linux"'
+}
+
+@test "shp buildrun create --node-selector single label" {
+    # generate random names for our buildrun
+	buildrun_name=$(random_name)
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp buildrun create ${buildrun_name} --buildref-name=${build_name} --node-selector="kubernetes.io/hostname=node-1"
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "BuildRun created \"${buildrun_name}\" for Build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get buildruns.shipwright.io/${buildrun_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output '{"kubernetes.io/hostname":"node-1"}'
+}
+
+@test "shp buildrun create --node-selector multiple labels" {
+    # generate random names for our buildrun
+	buildrun_name=$(random_name)
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp buildrun create ${buildrun_name} --buildref-name=${build_name} --node-selector="kubernetes.io/hostname=node-1"  --node-selector="kubernetes.io/os=linux"
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "BuildRun created \"${buildrun_name}\" for Build \"${build_name}\""
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get buildruns.shipwright.io/${buildrun_name} -ojsonpath="{.spec.nodeSelector}"
+	assert_success
+
+    assert_output --partial '"kubernetes.io/hostname":"node-1"'
+    assert_output --partial '"kubernetes.io/os":"linux"'
+}
+
+
+@test "shp build run --node-selector set" {
+    # generate random names for our build
+	build_name=$(random_name)
+
+    # create a Build with node selector 
+    run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-fake-image
+    assert_success
+
+    # ensure that the build was successfully created
+	assert_output --partial "Created build \"${build_name}\""
+
+    # get the build object
+	run kubectl get builds.shipwright.io/${build_name}
+	assert_success
+
+    run shp build run ${build_name} --node-selector="kubernetes.io/hostname=node-1"
+
+    # get the jsonpath of Build object .spec.nodeSelector
+	run kubectl get buildruns.shipwright.io -ojsonpath='{.items[*].spec.nodeSelector}' 
+	assert_success
+    assert_output --partial '"kubernetes.io/hostname":"node-1"'
+}

--- a/test/e2e/output-image-labels-annotations.bats
+++ b/test/e2e/output-image-labels-annotations.bats
@@ -19,7 +19,7 @@ teardown() {
 	buildrun_name=$(random_name)
 
 	# create a Build with a label and an annotation
-	run shp build create ${build_name} --source-url=https://github.com/shipwright-io/sample-go --output-image=my-image --output-image-label=foo=bar --output-image-annotation=created-by=shipwright
+	run shp build create ${build_name} --source-git-url=https://github.com/shipwright-io/sample-go --output-image=my-image --output-image-label=foo=bar --output-image-annotation=created-by=shipwright
 	assert_success
 
 	# ensure that the build was successfully created

--- a/test/e2e/run-follow.bats
+++ b/test/e2e/run-follow.bats
@@ -21,7 +21,7 @@ teardown() {
 
     # create a Build
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image}
     assert_success
@@ -53,7 +53,7 @@ teardown() {
 
     # create a Build which will fail
     run shp build create ${build_name} \
-        --source-url=https://github.com/shipwright-io/sample-go \
+        --source-git-url=https://github.com/shipwright-io/sample-go \
         --source-context-dir=source-build \
         --output-image=${output_image} \
         --strategy-name buildkit

--- a/test/e2e/upload.bats
+++ b/test/e2e/upload.bats
@@ -39,7 +39,7 @@ function assert_shp_upload_follow_output() {
 	# change directory (cd) during the build process, so if the directory is not uploaded properly
 	# the actual build will fail
 	run shp build create ${build_name} \
-		--source-url="${source_url}" \
+		--source-git-url="${source_url}" \
 		--source-context-dir="source-build" \
 		--output-image="${output_image}"
 	assert_success
@@ -82,8 +82,8 @@ function assert_shp_upload_follow_output() {
 
 	# Verify that invalid prune options are not accepted
 	run shp build create ${build_name} \
-		--source-bundle-image="$(get_output_image source-bundle):latest" \
-		--source-bundle-prune=Magic
+		--source-oci-artifact-image="$(get_output_image source-bundle):latest" \
+		--source-oci-artifact-prune=Magic
 	assert_failure
 	assert_output --partial 'invalid argument'
 
@@ -95,8 +95,8 @@ function assert_shp_upload_follow_output() {
 	# from the local shp client.
 	#
 	run shp build create ${build_name} \
-		--source-bundle-image="$(get_output_image source-bundle):latest" \
-		--source-bundle-prune=AfterPull \
+		--source-oci-artifact-image="$(get_output_image source-bundle):latest" \
+		--source-oci-artifact-prune=AfterPull \
 		--source-context-dir="docker-build" \
 		--dockerfile=Dockerfile \
 		--strategy-name=kaniko \

--- a/test/stub/client.go
+++ b/test/stub/client.go
@@ -3,7 +3,7 @@ package stub
 import (
 	"log"
 
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -13,7 +13,7 @@ import (
 // NewFakeClient creates a fake client with Shipwright's Build scheme.
 func NewFakeClient() dynamic.Interface {
 	scheme := runtime.NewScheme()
-	if err := buildv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+	if err := buildv1beta1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		log.Fatal(err)
 	}
 	return fake.NewSimpleDynamicClient(scheme)

--- a/test/stub/stub.go
+++ b/test/stub/stub.go
@@ -1,33 +1,36 @@
 package stub
 
 import (
-	buildv1alpha1 "github.com/shipwright-io/build/pkg/apis/build/v1alpha1"
+	buildv1beta1 "github.com/shipwright-io/build/pkg/apis/build/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BuildRunEmpty simple empty BuildRun instance.
-func BuildRunEmpty() buildv1alpha1.BuildRun {
-	return buildv1alpha1.BuildRun{}
+func BuildRunEmpty() buildv1beta1.BuildRun {
+	return buildv1beta1.BuildRun{}
 }
 
 // TestBuild returns instance of Build for testing purposes
-func TestBuild(name, image, source string) *buildv1alpha1.Build {
-	strategyKind := buildv1alpha1.ClusterBuildStrategyKind
+func TestBuild(name, image, source string) *buildv1beta1.Build {
+	strategyKind := buildv1beta1.ClusterBuildStrategyKind
 
-	result := &buildv1alpha1.Build{
+	result := &buildv1beta1.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: buildv1alpha1.BuildSpec{
-			Strategy: buildv1alpha1.Strategy{
+		Spec: buildv1beta1.BuildSpec{
+			Strategy: buildv1beta1.Strategy{
 				Name: "buildah",
 				Kind: &strategyKind,
 			},
-			Source: buildv1alpha1.Source{
-				URL: &source,
+			Source: &buildv1beta1.Source{
+				Type: buildv1beta1.GitType,
+				Git: &buildv1beta1.Git{
+					URL: source,
+				},
 			},
-			Output: buildv1alpha1.Image{
+			Output: buildv1beta1.Image{
 				Image: image,
 			},
 		},

--- a/vendor/github.com/onsi/gomega/CHANGELOG.md
+++ b/vendor/github.com/onsi/gomega/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.37.0
+
+### Features
+- add To/ToNot/NotTo aliases for AsyncAssertion [5666f98]
+
 ## 1.36.3
 
 ### Maintenance

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-const GOMEGA_VERSION = "1.36.3"
+const GOMEGA_VERSION = "1.37.0"
 
 const nilGomegaPanic = `You are trying to make an assertion, but haven't registered Gomega's fail handler.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().

--- a/vendor/github.com/onsi/gomega/internal/async_assertion.go
+++ b/vendor/github.com/onsi/gomega/internal/async_assertion.go
@@ -145,10 +145,22 @@ func (assertion *AsyncAssertion) Should(matcher types.GomegaMatcher, optionalDes
 	return assertion.match(matcher, true, optionalDescription...)
 }
 
+func (assertion *AsyncAssertion) To(matcher types.GomegaMatcher, optionalDescription ...any) bool {
+	return assertion.Should(matcher, optionalDescription...)
+}
+
 func (assertion *AsyncAssertion) ShouldNot(matcher types.GomegaMatcher, optionalDescription ...any) bool {
 	assertion.g.THelper()
 	vetOptionalDescription("Asynchronous assertion", optionalDescription...)
 	return assertion.match(matcher, false, optionalDescription...)
+}
+
+func (assertion *AsyncAssertion) ToNot(matcher types.GomegaMatcher, optionalDescription ...any) bool {
+	return assertion.ShouldNot(matcher, optionalDescription...)
+}
+
+func (assertion *AsyncAssertion) NotTo(matcher types.GomegaMatcher, optionalDescription ...any) bool {
+	return assertion.ShouldNot(matcher, optionalDescription...)
 }
 
 func (assertion *AsyncAssertion) buildDescription(optionalDescription ...any) string {

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -70,6 +70,11 @@ type AsyncAssertion interface {
 	Should(matcher GomegaMatcher, optionalDescription ...any) bool
 	ShouldNot(matcher GomegaMatcher, optionalDescription ...any) bool
 
+	// equivalent to above
+	To(matcher GomegaMatcher, optionalDescription ...any) bool
+	ToNot(matcher GomegaMatcher, optionalDescription ...any) bool
+	NotTo(matcher GomegaMatcher, optionalDescription ...any) bool
+
 	WithOffset(offset int) AsyncAssertion
 	WithTimeout(interval time.Duration) AsyncAssertion
 	WithPolling(interval time.Duration) AsyncAssertion

--- a/vendor/golang.org/x/net/html/atom/table.go
+++ b/vendor/golang.org/x/net/html/atom/table.go
@@ -11,23 +11,23 @@ const (
 	AcceptCharset             Atom = 0x1a0e
 	Accesskey                 Atom = 0x2c09
 	Acronym                   Atom = 0xaa07
-	Action                    Atom = 0x27206
-	Address                   Atom = 0x6f307
+	Action                    Atom = 0x26506
+	Address                   Atom = 0x6f107
 	Align                     Atom = 0xb105
-	Allowfullscreen           Atom = 0x2080f
+	Allowfullscreen           Atom = 0x3280f
 	Allowpaymentrequest       Atom = 0xc113
 	Allowusermedia            Atom = 0xdd0e
 	Alt                       Atom = 0xf303
 	Annotation                Atom = 0x1c90a
 	AnnotationXml             Atom = 0x1c90e
-	Applet                    Atom = 0x31906
-	Area                      Atom = 0x35604
-	Article                   Atom = 0x3fc07
+	Applet                    Atom = 0x30806
+	Area                      Atom = 0x35004
+	Article                   Atom = 0x3f607
 	As                        Atom = 0x3c02
 	Aside                     Atom = 0x10705
 	Async                     Atom = 0xff05
 	Audio                     Atom = 0x11505
-	Autocomplete              Atom = 0x2780c
+	Autocomplete              Atom = 0x26b0c
 	Autofocus                 Atom = 0x12109
 	Autoplay                  Atom = 0x13c08
 	B                         Atom = 0x101
@@ -43,34 +43,34 @@ const (
 	Br                        Atom = 0x202
 	Button                    Atom = 0x19106
 	Canvas                    Atom = 0x10306
-	Caption                   Atom = 0x23107
-	Center                    Atom = 0x22006
-	Challenge                 Atom = 0x29b09
+	Caption                   Atom = 0x22407
+	Center                    Atom = 0x21306
+	Challenge                 Atom = 0x28e09
 	Charset                   Atom = 0x2107
-	Checked                   Atom = 0x47907
+	Checked                   Atom = 0x5b507
 	Cite                      Atom = 0x19c04
-	Class                     Atom = 0x56405
-	Code                      Atom = 0x5c504
+	Class                     Atom = 0x55805
+	Code                      Atom = 0x5ee04
 	Col                       Atom = 0x1ab03
 	Colgroup                  Atom = 0x1ab08
 	Color                     Atom = 0x1bf05
 	Cols                      Atom = 0x1c404
 	Colspan                   Atom = 0x1c407
 	Command                   Atom = 0x1d707
-	Content                   Atom = 0x58b07
-	Contenteditable           Atom = 0x58b0f
-	Contextmenu               Atom = 0x3800b
+	Content                   Atom = 0x57b07
+	Contenteditable           Atom = 0x57b0f
+	Contextmenu               Atom = 0x37a0b
 	Controls                  Atom = 0x1de08
-	Coords                    Atom = 0x1ea06
-	Crossorigin               Atom = 0x1fb0b
-	Data                      Atom = 0x4a504
-	Datalist                  Atom = 0x4a508
-	Datetime                  Atom = 0x2b808
-	Dd                        Atom = 0x2d702
+	Coords                    Atom = 0x1f006
+	Crossorigin               Atom = 0x1fa0b
+	Data                      Atom = 0x49904
+	Datalist                  Atom = 0x49908
+	Datetime                  Atom = 0x2ab08
+	Dd                        Atom = 0x2bf02
 	Default                   Atom = 0x10a07
-	Defer                     Atom = 0x5c705
-	Del                       Atom = 0x45203
-	Desc                      Atom = 0x56104
+	Defer                     Atom = 0x5f005
+	Del                       Atom = 0x44c03
+	Desc                      Atom = 0x55504
 	Details                   Atom = 0x7207
 	Dfn                       Atom = 0x8703
 	Dialog                    Atom = 0xbb06
@@ -78,106 +78,106 @@ const (
 	Dirname                   Atom = 0x9307
 	Disabled                  Atom = 0x16408
 	Div                       Atom = 0x16b03
-	Dl                        Atom = 0x5e602
-	Download                  Atom = 0x46308
+	Dl                        Atom = 0x5d602
+	Download                  Atom = 0x45d08
 	Draggable                 Atom = 0x17a09
-	Dropzone                  Atom = 0x40508
-	Dt                        Atom = 0x64b02
+	Dropzone                  Atom = 0x3ff08
+	Dt                        Atom = 0x64002
 	Em                        Atom = 0x6e02
 	Embed                     Atom = 0x6e05
-	Enctype                   Atom = 0x28d07
-	Face                      Atom = 0x21e04
-	Fieldset                  Atom = 0x22608
-	Figcaption                Atom = 0x22e0a
-	Figure                    Atom = 0x24806
+	Enctype                   Atom = 0x28007
+	Face                      Atom = 0x21104
+	Fieldset                  Atom = 0x21908
+	Figcaption                Atom = 0x2210a
+	Figure                    Atom = 0x23b06
 	Font                      Atom = 0x3f04
 	Footer                    Atom = 0xf606
-	For                       Atom = 0x25403
-	ForeignObject             Atom = 0x2540d
-	Foreignobject             Atom = 0x2610d
-	Form                      Atom = 0x26e04
-	Formaction                Atom = 0x26e0a
-	Formenctype               Atom = 0x2890b
-	Formmethod                Atom = 0x2a40a
-	Formnovalidate            Atom = 0x2ae0e
-	Formtarget                Atom = 0x2c00a
+	For                       Atom = 0x24703
+	ForeignObject             Atom = 0x2470d
+	Foreignobject             Atom = 0x2540d
+	Form                      Atom = 0x26104
+	Formaction                Atom = 0x2610a
+	Formenctype               Atom = 0x27c0b
+	Formmethod                Atom = 0x2970a
+	Formnovalidate            Atom = 0x2a10e
+	Formtarget                Atom = 0x2b30a
 	Frame                     Atom = 0x8b05
 	Frameset                  Atom = 0x8b08
 	H1                        Atom = 0x15c02
-	H2                        Atom = 0x2de02
-	H3                        Atom = 0x30d02
-	H4                        Atom = 0x34502
-	H5                        Atom = 0x34f02
-	H6                        Atom = 0x64d02
-	Head                      Atom = 0x33104
-	Header                    Atom = 0x33106
-	Headers                   Atom = 0x33107
+	H2                        Atom = 0x56102
+	H3                        Atom = 0x2cd02
+	H4                        Atom = 0x2fc02
+	H5                        Atom = 0x33f02
+	H6                        Atom = 0x34902
+	Head                      Atom = 0x32004
+	Header                    Atom = 0x32006
+	Headers                   Atom = 0x32007
 	Height                    Atom = 0x5206
-	Hgroup                    Atom = 0x2ca06
-	Hidden                    Atom = 0x2d506
-	High                      Atom = 0x2db04
+	Hgroup                    Atom = 0x64206
+	Hidden                    Atom = 0x2bd06
+	High                      Atom = 0x2ca04
 	Hr                        Atom = 0x15702
-	Href                      Atom = 0x2e004
-	Hreflang                  Atom = 0x2e008
+	Href                      Atom = 0x2cf04
+	Hreflang                  Atom = 0x2cf08
 	Html                      Atom = 0x5604
-	HttpEquiv                 Atom = 0x2e80a
+	HttpEquiv                 Atom = 0x2d70a
 	I                         Atom = 0x601
-	Icon                      Atom = 0x58a04
+	Icon                      Atom = 0x57a04
 	Id                        Atom = 0x10902
-	Iframe                    Atom = 0x2fc06
-	Image                     Atom = 0x30205
-	Img                       Atom = 0x30703
-	Input                     Atom = 0x44b05
-	Inputmode                 Atom = 0x44b09
-	Ins                       Atom = 0x20403
-	Integrity                 Atom = 0x23f09
+	Iframe                    Atom = 0x2eb06
+	Image                     Atom = 0x2f105
+	Img                       Atom = 0x2f603
+	Input                     Atom = 0x44505
+	Inputmode                 Atom = 0x44509
+	Ins                       Atom = 0x20303
+	Integrity                 Atom = 0x23209
 	Is                        Atom = 0x16502
-	Isindex                   Atom = 0x30f07
-	Ismap                     Atom = 0x31605
-	Itemid                    Atom = 0x38b06
+	Isindex                   Atom = 0x2fe07
+	Ismap                     Atom = 0x30505
+	Itemid                    Atom = 0x38506
 	Itemprop                  Atom = 0x19d08
-	Itemref                   Atom = 0x3cd07
-	Itemscope                 Atom = 0x67109
-	Itemtype                  Atom = 0x31f08
+	Itemref                   Atom = 0x3c707
+	Itemscope                 Atom = 0x66f09
+	Itemtype                  Atom = 0x30e08
 	Kbd                       Atom = 0xb903
 	Keygen                    Atom = 0x3206
 	Keytype                   Atom = 0xd607
 	Kind                      Atom = 0x17704
 	Label                     Atom = 0x5905
-	Lang                      Atom = 0x2e404
+	Lang                      Atom = 0x2d304
 	Legend                    Atom = 0x18106
 	Li                        Atom = 0xb202
 	Link                      Atom = 0x17404
-	List                      Atom = 0x4a904
-	Listing                   Atom = 0x4a907
+	List                      Atom = 0x49d04
+	Listing                   Atom = 0x49d07
 	Loop                      Atom = 0x5d04
 	Low                       Atom = 0xc303
 	Main                      Atom = 0x1004
 	Malignmark                Atom = 0xb00a
-	Manifest                  Atom = 0x6d708
-	Map                       Atom = 0x31803
+	Manifest                  Atom = 0x6d508
+	Map                       Atom = 0x30703
 	Mark                      Atom = 0xb604
-	Marquee                   Atom = 0x32707
-	Math                      Atom = 0x32e04
-	Max                       Atom = 0x33d03
-	Maxlength                 Atom = 0x33d09
+	Marquee                   Atom = 0x31607
+	Math                      Atom = 0x31d04
+	Max                       Atom = 0x33703
+	Maxlength                 Atom = 0x33709
 	Media                     Atom = 0xe605
 	Mediagroup                Atom = 0xe60a
-	Menu                      Atom = 0x38704
-	Menuitem                  Atom = 0x38708
-	Meta                      Atom = 0x4b804
+	Menu                      Atom = 0x38104
+	Menuitem                  Atom = 0x38108
+	Meta                      Atom = 0x4ac04
 	Meter                     Atom = 0x9805
-	Method                    Atom = 0x2a806
-	Mglyph                    Atom = 0x30806
-	Mi                        Atom = 0x34702
-	Min                       Atom = 0x34703
-	Minlength                 Atom = 0x34709
-	Mn                        Atom = 0x2b102
+	Method                    Atom = 0x29b06
+	Mglyph                    Atom = 0x2f706
+	Mi                        Atom = 0x34102
+	Min                       Atom = 0x34103
+	Minlength                 Atom = 0x34109
+	Mn                        Atom = 0x2a402
 	Mo                        Atom = 0xa402
-	Ms                        Atom = 0x67402
-	Mtext                     Atom = 0x35105
-	Multiple                  Atom = 0x35f08
-	Muted                     Atom = 0x36705
+	Ms                        Atom = 0x67202
+	Mtext                     Atom = 0x34b05
+	Multiple                  Atom = 0x35908
+	Muted                     Atom = 0x36105
 	Name                      Atom = 0x9604
 	Nav                       Atom = 0x1303
 	Nobr                      Atom = 0x3704
@@ -185,101 +185,101 @@ const (
 	Noframes                  Atom = 0x8908
 	Nomodule                  Atom = 0xa208
 	Nonce                     Atom = 0x1a605
-	Noscript                  Atom = 0x21608
-	Novalidate                Atom = 0x2b20a
-	Object                    Atom = 0x26806
+	Noscript                  Atom = 0x2c208
+	Novalidate                Atom = 0x2a50a
+	Object                    Atom = 0x25b06
 	Ol                        Atom = 0x13702
 	Onabort                   Atom = 0x19507
-	Onafterprint              Atom = 0x2360c
-	Onautocomplete            Atom = 0x2760e
-	Onautocompleteerror       Atom = 0x27613
-	Onauxclick                Atom = 0x61f0a
-	Onbeforeprint             Atom = 0x69e0d
-	Onbeforeunload            Atom = 0x6e70e
-	Onblur                    Atom = 0x56d06
+	Onafterprint              Atom = 0x2290c
+	Onautocomplete            Atom = 0x2690e
+	Onautocompleteerror       Atom = 0x26913
+	Onauxclick                Atom = 0x6140a
+	Onbeforeprint             Atom = 0x69c0d
+	Onbeforeunload            Atom = 0x6e50e
+	Onblur                    Atom = 0x1ea06
 	Oncancel                  Atom = 0x11908
 	Oncanplay                 Atom = 0x14d09
 	Oncanplaythrough          Atom = 0x14d10
-	Onchange                  Atom = 0x41b08
-	Onclick                   Atom = 0x2f507
-	Onclose                   Atom = 0x36c07
-	Oncontextmenu             Atom = 0x37e0d
-	Oncopy                    Atom = 0x39106
-	Oncuechange               Atom = 0x3970b
-	Oncut                     Atom = 0x3a205
-	Ondblclick                Atom = 0x3a70a
-	Ondrag                    Atom = 0x3b106
-	Ondragend                 Atom = 0x3b109
-	Ondragenter               Atom = 0x3ba0b
-	Ondragexit                Atom = 0x3c50a
-	Ondragleave               Atom = 0x3df0b
-	Ondragover                Atom = 0x3ea0a
-	Ondragstart               Atom = 0x3f40b
-	Ondrop                    Atom = 0x40306
-	Ondurationchange          Atom = 0x41310
-	Onemptied                 Atom = 0x40a09
-	Onended                   Atom = 0x42307
-	Onerror                   Atom = 0x42a07
-	Onfocus                   Atom = 0x43107
-	Onhashchange              Atom = 0x43d0c
-	Oninput                   Atom = 0x44907
-	Oninvalid                 Atom = 0x45509
-	Onkeydown                 Atom = 0x45e09
-	Onkeypress                Atom = 0x46b0a
-	Onkeyup                   Atom = 0x48007
-	Onlanguagechange          Atom = 0x48d10
-	Onload                    Atom = 0x49d06
-	Onloadeddata              Atom = 0x49d0c
-	Onloadedmetadata          Atom = 0x4b010
-	Onloadend                 Atom = 0x4c609
-	Onloadstart               Atom = 0x4cf0b
-	Onmessage                 Atom = 0x4da09
-	Onmessageerror            Atom = 0x4da0e
-	Onmousedown               Atom = 0x4e80b
-	Onmouseenter              Atom = 0x4f30c
-	Onmouseleave              Atom = 0x4ff0c
-	Onmousemove               Atom = 0x50b0b
-	Onmouseout                Atom = 0x5160a
-	Onmouseover               Atom = 0x5230b
-	Onmouseup                 Atom = 0x52e09
-	Onmousewheel              Atom = 0x53c0c
-	Onoffline                 Atom = 0x54809
-	Ononline                  Atom = 0x55108
-	Onpagehide                Atom = 0x5590a
-	Onpageshow                Atom = 0x5730a
-	Onpaste                   Atom = 0x57f07
-	Onpause                   Atom = 0x59a07
-	Onplay                    Atom = 0x5a406
-	Onplaying                 Atom = 0x5a409
-	Onpopstate                Atom = 0x5ad0a
-	Onprogress                Atom = 0x5b70a
-	Onratechange              Atom = 0x5cc0c
-	Onrejectionhandled        Atom = 0x5d812
-	Onreset                   Atom = 0x5ea07
-	Onresize                  Atom = 0x5f108
-	Onscroll                  Atom = 0x60008
-	Onsecuritypolicyviolation Atom = 0x60819
-	Onseeked                  Atom = 0x62908
-	Onseeking                 Atom = 0x63109
-	Onselect                  Atom = 0x63a08
-	Onshow                    Atom = 0x64406
-	Onsort                    Atom = 0x64f06
-	Onstalled                 Atom = 0x65909
-	Onstorage                 Atom = 0x66209
-	Onsubmit                  Atom = 0x66b08
-	Onsuspend                 Atom = 0x67b09
+	Onchange                  Atom = 0x41508
+	Onclick                   Atom = 0x2e407
+	Onclose                   Atom = 0x36607
+	Oncontextmenu             Atom = 0x3780d
+	Oncopy                    Atom = 0x38b06
+	Oncuechange               Atom = 0x3910b
+	Oncut                     Atom = 0x39c05
+	Ondblclick                Atom = 0x3a10a
+	Ondrag                    Atom = 0x3ab06
+	Ondragend                 Atom = 0x3ab09
+	Ondragenter               Atom = 0x3b40b
+	Ondragexit                Atom = 0x3bf0a
+	Ondragleave               Atom = 0x3d90b
+	Ondragover                Atom = 0x3e40a
+	Ondragstart               Atom = 0x3ee0b
+	Ondrop                    Atom = 0x3fd06
+	Ondurationchange          Atom = 0x40d10
+	Onemptied                 Atom = 0x40409
+	Onended                   Atom = 0x41d07
+	Onerror                   Atom = 0x42407
+	Onfocus                   Atom = 0x42b07
+	Onhashchange              Atom = 0x4370c
+	Oninput                   Atom = 0x44307
+	Oninvalid                 Atom = 0x44f09
+	Onkeydown                 Atom = 0x45809
+	Onkeypress                Atom = 0x4650a
+	Onkeyup                   Atom = 0x47407
+	Onlanguagechange          Atom = 0x48110
+	Onload                    Atom = 0x49106
+	Onloadeddata              Atom = 0x4910c
+	Onloadedmetadata          Atom = 0x4a410
+	Onloadend                 Atom = 0x4ba09
+	Onloadstart               Atom = 0x4c30b
+	Onmessage                 Atom = 0x4ce09
+	Onmessageerror            Atom = 0x4ce0e
+	Onmousedown               Atom = 0x4dc0b
+	Onmouseenter              Atom = 0x4e70c
+	Onmouseleave              Atom = 0x4f30c
+	Onmousemove               Atom = 0x4ff0b
+	Onmouseout                Atom = 0x50a0a
+	Onmouseover               Atom = 0x5170b
+	Onmouseup                 Atom = 0x52209
+	Onmousewheel              Atom = 0x5300c
+	Onoffline                 Atom = 0x53c09
+	Ononline                  Atom = 0x54508
+	Onpagehide                Atom = 0x54d0a
+	Onpageshow                Atom = 0x5630a
+	Onpaste                   Atom = 0x56f07
+	Onpause                   Atom = 0x58a07
+	Onplay                    Atom = 0x59406
+	Onplaying                 Atom = 0x59409
+	Onpopstate                Atom = 0x59d0a
+	Onprogress                Atom = 0x5a70a
+	Onratechange              Atom = 0x5bc0c
+	Onrejectionhandled        Atom = 0x5c812
+	Onreset                   Atom = 0x5da07
+	Onresize                  Atom = 0x5e108
+	Onscroll                  Atom = 0x5f508
+	Onsecuritypolicyviolation Atom = 0x5fd19
+	Onseeked                  Atom = 0x61e08
+	Onseeking                 Atom = 0x62609
+	Onselect                  Atom = 0x62f08
+	Onshow                    Atom = 0x63906
+	Onsort                    Atom = 0x64d06
+	Onstalled                 Atom = 0x65709
+	Onstorage                 Atom = 0x66009
+	Onsubmit                  Atom = 0x66908
+	Onsuspend                 Atom = 0x67909
 	Ontimeupdate              Atom = 0x400c
-	Ontoggle                  Atom = 0x68408
-	Onunhandledrejection      Atom = 0x68c14
-	Onunload                  Atom = 0x6ab08
-	Onvolumechange            Atom = 0x6b30e
-	Onwaiting                 Atom = 0x6c109
-	Onwheel                   Atom = 0x6ca07
+	Ontoggle                  Atom = 0x68208
+	Onunhandledrejection      Atom = 0x68a14
+	Onunload                  Atom = 0x6a908
+	Onvolumechange            Atom = 0x6b10e
+	Onwaiting                 Atom = 0x6bf09
+	Onwheel                   Atom = 0x6c807
 	Open                      Atom = 0x1a304
 	Optgroup                  Atom = 0x5f08
-	Optimum                   Atom = 0x6d107
-	Option                    Atom = 0x6e306
-	Output                    Atom = 0x51d06
+	Optimum                   Atom = 0x6cf07
+	Option                    Atom = 0x6e106
+	Output                    Atom = 0x51106
 	P                         Atom = 0xc01
 	Param                     Atom = 0xc05
 	Pattern                   Atom = 0x6607
@@ -288,466 +288,468 @@ const (
 	Placeholder               Atom = 0x1310b
 	Plaintext                 Atom = 0x1b209
 	Playsinline               Atom = 0x1400b
-	Poster                    Atom = 0x2cf06
-	Pre                       Atom = 0x47003
-	Preload                   Atom = 0x48607
-	Progress                  Atom = 0x5b908
-	Prompt                    Atom = 0x53606
-	Public                    Atom = 0x58606
+	Poster                    Atom = 0x64706
+	Pre                       Atom = 0x46a03
+	Preload                   Atom = 0x47a07
+	Progress                  Atom = 0x5a908
+	Prompt                    Atom = 0x52a06
+	Public                    Atom = 0x57606
 	Q                         Atom = 0xcf01
 	Radiogroup                Atom = 0x30a
 	Rb                        Atom = 0x3a02
-	Readonly                  Atom = 0x35708
-	Referrerpolicy            Atom = 0x3d10e
-	Rel                       Atom = 0x48703
-	Required                  Atom = 0x24c08
+	Readonly                  Atom = 0x35108
+	Referrerpolicy            Atom = 0x3cb0e
+	Rel                       Atom = 0x47b03
+	Required                  Atom = 0x23f08
 	Reversed                  Atom = 0x8008
 	Rows                      Atom = 0x9c04
 	Rowspan                   Atom = 0x9c07
-	Rp                        Atom = 0x23c02
+	Rp                        Atom = 0x22f02
 	Rt                        Atom = 0x19a02
 	Rtc                       Atom = 0x19a03
 	Ruby                      Atom = 0xfb04
 	S                         Atom = 0x2501
 	Samp                      Atom = 0x7804
 	Sandbox                   Atom = 0x12907
-	Scope                     Atom = 0x67505
-	Scoped                    Atom = 0x67506
-	Script                    Atom = 0x21806
-	Seamless                  Atom = 0x37108
-	Section                   Atom = 0x56807
-	Select                    Atom = 0x63c06
-	Selected                  Atom = 0x63c08
-	Shape                     Atom = 0x1e505
-	Size                      Atom = 0x5f504
-	Sizes                     Atom = 0x5f505
-	Slot                      Atom = 0x1ef04
-	Small                     Atom = 0x20605
-	Sortable                  Atom = 0x65108
-	Sorted                    Atom = 0x33706
-	Source                    Atom = 0x37806
-	Spacer                    Atom = 0x43706
+	Scope                     Atom = 0x67305
+	Scoped                    Atom = 0x67306
+	Script                    Atom = 0x2c406
+	Seamless                  Atom = 0x36b08
+	Search                    Atom = 0x55c06
+	Section                   Atom = 0x1e507
+	Select                    Atom = 0x63106
+	Selected                  Atom = 0x63108
+	Shape                     Atom = 0x1f505
+	Size                      Atom = 0x5e504
+	Sizes                     Atom = 0x5e505
+	Slot                      Atom = 0x20504
+	Small                     Atom = 0x32605
+	Sortable                  Atom = 0x64f08
+	Sorted                    Atom = 0x37206
+	Source                    Atom = 0x43106
+	Spacer                    Atom = 0x46e06
 	Span                      Atom = 0x9f04
-	Spellcheck                Atom = 0x4740a
-	Src                       Atom = 0x5c003
-	Srcdoc                    Atom = 0x5c006
-	Srclang                   Atom = 0x5f907
-	Srcset                    Atom = 0x6f906
-	Start                     Atom = 0x3fa05
-	Step                      Atom = 0x58304
+	Spellcheck                Atom = 0x5b00a
+	Src                       Atom = 0x5e903
+	Srcdoc                    Atom = 0x5e906
+	Srclang                   Atom = 0x6f707
+	Srcset                    Atom = 0x6fe06
+	Start                     Atom = 0x3f405
+	Step                      Atom = 0x57304
 	Strike                    Atom = 0xd206
-	Strong                    Atom = 0x6dd06
-	Style                     Atom = 0x6ff05
-	Sub                       Atom = 0x66d03
-	Summary                   Atom = 0x70407
-	Sup                       Atom = 0x70b03
-	Svg                       Atom = 0x70e03
-	System                    Atom = 0x71106
-	Tabindex                  Atom = 0x4be08
-	Table                     Atom = 0x59505
-	Target                    Atom = 0x2c406
+	Strong                    Atom = 0x6db06
+	Style                     Atom = 0x70405
+	Sub                       Atom = 0x66b03
+	Summary                   Atom = 0x70907
+	Sup                       Atom = 0x71003
+	Svg                       Atom = 0x71303
+	System                    Atom = 0x71606
+	Tabindex                  Atom = 0x4b208
+	Table                     Atom = 0x58505
+	Target                    Atom = 0x2b706
 	Tbody                     Atom = 0x2705
 	Td                        Atom = 0x9202
-	Template                  Atom = 0x71408
-	Textarea                  Atom = 0x35208
+	Template                  Atom = 0x71908
+	Textarea                  Atom = 0x34c08
 	Tfoot                     Atom = 0xf505
 	Th                        Atom = 0x15602
-	Thead                     Atom = 0x33005
+	Thead                     Atom = 0x31f05
 	Time                      Atom = 0x4204
 	Title                     Atom = 0x11005
 	Tr                        Atom = 0xcc02
 	Track                     Atom = 0x1ba05
-	Translate                 Atom = 0x1f209
+	Translate                 Atom = 0x20809
 	Tt                        Atom = 0x6802
 	Type                      Atom = 0xd904
-	Typemustmatch             Atom = 0x2900d
+	Typemustmatch             Atom = 0x2830d
 	U                         Atom = 0xb01
 	Ul                        Atom = 0xa702
 	Updateviacache            Atom = 0x460e
-	Usemap                    Atom = 0x59e06
+	Usemap                    Atom = 0x58e06
 	Value                     Atom = 0x1505
 	Var                       Atom = 0x16d03
-	Video                     Atom = 0x2f105
-	Wbr                       Atom = 0x57c03
-	Width                     Atom = 0x64905
-	Workertype                Atom = 0x71c0a
-	Wrap                      Atom = 0x72604
+	Video                     Atom = 0x2e005
+	Wbr                       Atom = 0x56c03
+	Width                     Atom = 0x63e05
+	Workertype                Atom = 0x7210a
+	Wrap                      Atom = 0x72b04
 	Xmp                       Atom = 0x12f03
 )
 
-const hash0 = 0x81cdf10e
+const hash0 = 0x84f70e16
 
 const maxAtomLen = 25
 
 var table = [1 << 9]Atom{
-	0x1:   0xe60a,  // mediagroup
-	0x2:   0x2e404, // lang
-	0x4:   0x2c09,  // accesskey
-	0x5:   0x8b08,  // frameset
-	0x7:   0x63a08, // onselect
-	0x8:   0x71106, // system
-	0xa:   0x64905, // width
-	0xc:   0x2890b, // formenctype
-	0xd:   0x13702, // ol
-	0xe:   0x3970b, // oncuechange
-	0x10:  0x14b03, // bdo
-	0x11:  0x11505, // audio
-	0x12:  0x17a09, // draggable
-	0x14:  0x2f105, // video
-	0x15:  0x2b102, // mn
-	0x16:  0x38704, // menu
-	0x17:  0x2cf06, // poster
-	0x19:  0xf606,  // footer
-	0x1a:  0x2a806, // method
-	0x1b:  0x2b808, // datetime
-	0x1c:  0x19507, // onabort
-	0x1d:  0x460e,  // updateviacache
-	0x1e:  0xff05,  // async
-	0x1f:  0x49d06, // onload
-	0x21:  0x11908, // oncancel
-	0x22:  0x62908, // onseeked
-	0x23:  0x30205, // image
-	0x24:  0x5d812, // onrejectionhandled
-	0x26:  0x17404, // link
-	0x27:  0x51d06, // output
-	0x28:  0x33104, // head
-	0x29:  0x4ff0c, // onmouseleave
-	0x2a:  0x57f07, // onpaste
-	0x2b:  0x5a409, // onplaying
-	0x2c:  0x1c407, // colspan
-	0x2f:  0x1bf05, // color
-	0x30:  0x5f504, // size
-	0x31:  0x2e80a, // http-equiv
-	0x33:  0x601,   // i
-	0x34:  0x5590a, // onpagehide
-	0x35:  0x68c14, // onunhandledrejection
-	0x37:  0x42a07, // onerror
-	0x3a:  0x3b08,  // basefont
-	0x3f:  0x1303,  // nav
-	0x40:  0x17704, // kind
-	0x41:  0x35708, // readonly
-	0x42:  0x30806, // mglyph
-	0x44:  0xb202,  // li
-	0x46:  0x2d506, // hidden
-	0x47:  0x70e03, // svg
-	0x48:  0x58304, // step
-	0x49:  0x23f09, // integrity
-	0x4a:  0x58606, // public
-	0x4c:  0x1ab03, // col
-	0x4d:  0x1870a, // blockquote
-	0x4e:  0x34f02, // h5
-	0x50:  0x5b908, // progress
-	0x51:  0x5f505, // sizes
-	0x52:  0x34502, // h4
-	0x56:  0x33005, // thead
-	0x57:  0xd607,  // keytype
-	0x58:  0x5b70a, // onprogress
-	0x59:  0x44b09, // inputmode
-	0x5a:  0x3b109, // ondragend
-	0x5d:  0x3a205, // oncut
-	0x5e:  0x43706, // spacer
-	0x5f:  0x1ab08, // colgroup
-	0x62:  0x16502, // is
-	0x65:  0x3c02,  // as
-	0x66:  0x54809, // onoffline
-	0x67:  0x33706, // sorted
-	0x69:  0x48d10, // onlanguagechange
-	0x6c:  0x43d0c, // onhashchange
-	0x6d:  0x9604,  // name
-	0x6e:  0xf505,  // tfoot
-	0x6f:  0x56104, // desc
-	0x70:  0x33d03, // max
-	0x72:  0x1ea06, // coords
-	0x73:  0x30d02, // h3
-	0x74:  0x6e70e, // onbeforeunload
-	0x75:  0x9c04,  // rows
-	0x76:  0x63c06, // select
-	0x77:  0x9805,  // meter
-	0x78:  0x38b06, // itemid
-	0x79:  0x53c0c, // onmousewheel
-	0x7a:  0x5c006, // srcdoc
-	0x7d:  0x1ba05, // track
-	0x7f:  0x31f08, // itemtype
-	0x82:  0xa402,  // mo
-	0x83:  0x41b08, // onchange
-	0x84:  0x33107, // headers
-	0x85:  0x5cc0c, // onratechange
-	0x86:  0x60819, // onsecuritypolicyviolation
-	0x88:  0x4a508, // datalist
-	0x89:  0x4e80b, // onmousedown
-	0x8a:  0x1ef04, // slot
-	0x8b:  0x4b010, // onloadedmetadata
-	0x8c:  0x1a06,  // accept
-	0x8d:  0x26806, // object
-	0x91:  0x6b30e, // onvolumechange
-	0x92:  0x2107,  // charset
-	0x93:  0x27613, // onautocompleteerror
-	0x94:  0xc113,  // allowpaymentrequest
-	0x95:  0x2804,  // body
-	0x96:  0x10a07, // default
-	0x97:  0x63c08, // selected
-	0x98:  0x21e04, // face
-	0x99:  0x1e505, // shape
-	0x9b:  0x68408, // ontoggle
-	0x9e:  0x64b02, // dt
-	0x9f:  0xb604,  // mark
-	0xa1:  0xb01,   // u
-	0xa4:  0x6ab08, // onunload
-	0xa5:  0x5d04,  // loop
-	0xa6:  0x16408, // disabled
-	0xaa:  0x42307, // onended
-	0xab:  0xb00a,  // malignmark
-	0xad:  0x67b09, // onsuspend
-	0xae:  0x35105, // mtext
-	0xaf:  0x64f06, // onsort
-	0xb0:  0x19d08, // itemprop
-	0xb3:  0x67109, // itemscope
-	0xb4:  0x17305, // blink
-	0xb6:  0x3b106, // ondrag
-	0xb7:  0xa702,  // ul
-	0xb8:  0x26e04, // form
-	0xb9:  0x12907, // sandbox
-	0xba:  0x8b05,  // frame
-	0xbb:  0x1505,  // value
-	0xbc:  0x66209, // onstorage
-	0xbf:  0xaa07,  // acronym
-	0xc0:  0x19a02, // rt
-	0xc2:  0x202,   // br
-	0xc3:  0x22608, // fieldset
-	0xc4:  0x2900d, // typemustmatch
-	0xc5:  0xa208,  // nomodule
-	0xc6:  0x6c07,  // noembed
-	0xc7:  0x69e0d, // onbeforeprint
-	0xc8:  0x19106, // button
-	0xc9:  0x2f507, // onclick
-	0xca:  0x70407, // summary
-	0xcd:  0xfb04,  // ruby
-	0xce:  0x56405, // class
-	0xcf:  0x3f40b, // ondragstart
-	0xd0:  0x23107, // caption
-	0xd4:  0xdd0e,  // allowusermedia
-	0xd5:  0x4cf0b, // onloadstart
-	0xd9:  0x16b03, // div
-	0xda:  0x4a904, // list
-	0xdb:  0x32e04, // math
-	0xdc:  0x44b05, // input
-	0xdf:  0x3ea0a, // ondragover
-	0xe0:  0x2de02, // h2
-	0xe2:  0x1b209, // plaintext
-	0xe4:  0x4f30c, // onmouseenter
-	0xe7:  0x47907, // checked
-	0xe8:  0x47003, // pre
-	0xea:  0x35f08, // multiple
-	0xeb:  0xba03,  // bdi
-	0xec:  0x33d09, // maxlength
-	0xed:  0xcf01,  // q
-	0xee:  0x61f0a, // onauxclick
-	0xf0:  0x57c03, // wbr
-	0xf2:  0x3b04,  // base
-	0xf3:  0x6e306, // option
-	0xf5:  0x41310, // ondurationchange
-	0xf7:  0x8908,  // noframes
-	0xf9:  0x40508, // dropzone
-	0xfb:  0x67505, // scope
-	0xfc:  0x8008,  // reversed
-	0xfd:  0x3ba0b, // ondragenter
-	0xfe:  0x3fa05, // start
-	0xff:  0x12f03, // xmp
-	0x100: 0x5f907, // srclang
-	0x101: 0x30703, // img
-	0x104: 0x101,   // b
-	0x105: 0x25403, // for
-	0x106: 0x10705, // aside
-	0x107: 0x44907, // oninput
-	0x108: 0x35604, // area
-	0x109: 0x2a40a, // formmethod
-	0x10a: 0x72604, // wrap
-	0x10c: 0x23c02, // rp
-	0x10d: 0x46b0a, // onkeypress
-	0x10e: 0x6802,  // tt
-	0x110: 0x34702, // mi
-	0x111: 0x36705, // muted
-	0x112: 0xf303,  // alt
-	0x113: 0x5c504, // code
-	0x114: 0x6e02,  // em
-	0x115: 0x3c50a, // ondragexit
-	0x117: 0x9f04,  // span
-	0x119: 0x6d708, // manifest
-	0x11a: 0x38708, // menuitem
-	0x11b: 0x58b07, // content
-	0x11d: 0x6c109, // onwaiting
-	0x11f: 0x4c609, // onloadend
-	0x121: 0x37e0d, // oncontextmenu
-	0x123: 0x56d06, // onblur
-	0x124: 0x3fc07, // article
-	0x125: 0x9303,  // dir
-	0x126: 0xef04,  // ping
-	0x127: 0x24c08, // required
-	0x128: 0x45509, // oninvalid
-	0x129: 0xb105,  // align
-	0x12b: 0x58a04, // icon
-	0x12c: 0x64d02, // h6
-	0x12d: 0x1c404, // cols
-	0x12e: 0x22e0a, // figcaption
-	0x12f: 0x45e09, // onkeydown
-	0x130: 0x66b08, // onsubmit
-	0x131: 0x14d09, // oncanplay
-	0x132: 0x70b03, // sup
-	0x133: 0xc01,   // p
-	0x135: 0x40a09, // onemptied
-	0x136: 0x39106, // oncopy
-	0x137: 0x19c04, // cite
-	0x138: 0x3a70a, // ondblclick
-	0x13a: 0x50b0b, // onmousemove
-	0x13c: 0x66d03, // sub
-	0x13d: 0x48703, // rel
-	0x13e: 0x5f08,  // optgroup
-	0x142: 0x9c07,  // rowspan
-	0x143: 0x37806, // source
-	0x144: 0x21608, // noscript
-	0x145: 0x1a304, // open
-	0x146: 0x20403, // ins
-	0x147: 0x2540d, // foreignObject
-	0x148: 0x5ad0a, // onpopstate
-	0x14a: 0x28d07, // enctype
-	0x14b: 0x2760e, // onautocomplete
-	0x14c: 0x35208, // textarea
-	0x14e: 0x2780c, // autocomplete
-	0x14f: 0x15702, // hr
-	0x150: 0x1de08, // controls
-	0x151: 0x10902, // id
-	0x153: 0x2360c, // onafterprint
-	0x155: 0x2610d, // foreignobject
-	0x156: 0x32707, // marquee
-	0x157: 0x59a07, // onpause
-	0x158: 0x5e602, // dl
-	0x159: 0x5206,  // height
-	0x15a: 0x34703, // min
-	0x15b: 0x9307,  // dirname
-	0x15c: 0x1f209, // translate
-	0x15d: 0x5604,  // html
-	0x15e: 0x34709, // minlength
-	0x15f: 0x48607, // preload
-	0x160: 0x71408, // template
-	0x161: 0x3df0b, // ondragleave
-	0x162: 0x3a02,  // rb
-	0x164: 0x5c003, // src
-	0x165: 0x6dd06, // strong
-	0x167: 0x7804,  // samp
-	0x168: 0x6f307, // address
-	0x169: 0x55108, // ononline
-	0x16b: 0x1310b, // placeholder
-	0x16c: 0x2c406, // target
-	0x16d: 0x20605, // small
-	0x16e: 0x6ca07, // onwheel
-	0x16f: 0x1c90a, // annotation
-	0x170: 0x4740a, // spellcheck
-	0x171: 0x7207,  // details
-	0x172: 0x10306, // canvas
-	0x173: 0x12109, // autofocus
-	0x174: 0xc05,   // param
-	0x176: 0x46308, // download
-	0x177: 0x45203, // del
-	0x178: 0x36c07, // onclose
-	0x179: 0xb903,  // kbd
-	0x17a: 0x31906, // applet
-	0x17b: 0x2e004, // href
-	0x17c: 0x5f108, // onresize
-	0x17e: 0x49d0c, // onloadeddata
-	0x180: 0xcc02,  // tr
-	0x181: 0x2c00a, // formtarget
-	0x182: 0x11005, // title
-	0x183: 0x6ff05, // style
-	0x184: 0xd206,  // strike
-	0x185: 0x59e06, // usemap
-	0x186: 0x2fc06, // iframe
-	0x187: 0x1004,  // main
-	0x189: 0x7b07,  // picture
-	0x18c: 0x31605, // ismap
-	0x18e: 0x4a504, // data
-	0x18f: 0x5905,  // label
-	0x191: 0x3d10e, // referrerpolicy
-	0x192: 0x15602, // th
-	0x194: 0x53606, // prompt
-	0x195: 0x56807, // section
-	0x197: 0x6d107, // optimum
-	0x198: 0x2db04, // high
-	0x199: 0x15c02, // h1
-	0x19a: 0x65909, // onstalled
-	0x19b: 0x16d03, // var
-	0x19c: 0x4204,  // time
-	0x19e: 0x67402, // ms
-	0x19f: 0x33106, // header
-	0x1a0: 0x4da09, // onmessage
-	0x1a1: 0x1a605, // nonce
-	0x1a2: 0x26e0a, // formaction
-	0x1a3: 0x22006, // center
-	0x1a4: 0x3704,  // nobr
-	0x1a5: 0x59505, // table
-	0x1a6: 0x4a907, // listing
-	0x1a7: 0x18106, // legend
-	0x1a9: 0x29b09, // challenge
-	0x1aa: 0x24806, // figure
-	0x1ab: 0xe605,  // media
-	0x1ae: 0xd904,  // type
-	0x1af: 0x3f04,  // font
-	0x1b0: 0x4da0e, // onmessageerror
-	0x1b1: 0x37108, // seamless
-	0x1b2: 0x8703,  // dfn
-	0x1b3: 0x5c705, // defer
-	0x1b4: 0xc303,  // low
-	0x1b5: 0x19a03, // rtc
-	0x1b6: 0x5230b, // onmouseover
-	0x1b7: 0x2b20a, // novalidate
-	0x1b8: 0x71c0a, // workertype
-	0x1ba: 0x3cd07, // itemref
-	0x1bd: 0x1,     // a
-	0x1be: 0x31803, // map
-	0x1bf: 0x400c,  // ontimeupdate
-	0x1c0: 0x15e07, // bgsound
-	0x1c1: 0x3206,  // keygen
-	0x1c2: 0x2705,  // tbody
-	0x1c5: 0x64406, // onshow
-	0x1c7: 0x2501,  // s
-	0x1c8: 0x6607,  // pattern
-	0x1cc: 0x14d10, // oncanplaythrough
-	0x1ce: 0x2d702, // dd
-	0x1cf: 0x6f906, // srcset
-	0x1d0: 0x17003, // big
-	0x1d2: 0x65108, // sortable
-	0x1d3: 0x48007, // onkeyup
-	0x1d5: 0x5a406, // onplay
-	0x1d7: 0x4b804, // meta
-	0x1d8: 0x40306, // ondrop
-	0x1da: 0x60008, // onscroll
-	0x1db: 0x1fb0b, // crossorigin
-	0x1dc: 0x5730a, // onpageshow
-	0x1dd: 0x4,     // abbr
-	0x1de: 0x9202,  // td
-	0x1df: 0x58b0f, // contenteditable
-	0x1e0: 0x27206, // action
-	0x1e1: 0x1400b, // playsinline
-	0x1e2: 0x43107, // onfocus
-	0x1e3: 0x2e008, // hreflang
-	0x1e5: 0x5160a, // onmouseout
-	0x1e6: 0x5ea07, // onreset
-	0x1e7: 0x13c08, // autoplay
-	0x1e8: 0x63109, // onseeking
-	0x1ea: 0x67506, // scoped
-	0x1ec: 0x30a,   // radiogroup
-	0x1ee: 0x3800b, // contextmenu
-	0x1ef: 0x52e09, // onmouseup
-	0x1f1: 0x2ca06, // hgroup
-	0x1f2: 0x2080f, // allowfullscreen
-	0x1f3: 0x4be08, // tabindex
-	0x1f6: 0x30f07, // isindex
-	0x1f7: 0x1a0e,  // accept-charset
-	0x1f8: 0x2ae0e, // formnovalidate
-	0x1fb: 0x1c90e, // annotation-xml
-	0x1fc: 0x6e05,  // embed
-	0x1fd: 0x21806, // script
-	0x1fe: 0xbb06,  // dialog
-	0x1ff: 0x1d707, // command
+	0x1:   0x3ff08, // dropzone
+	0x2:   0x3b08,  // basefont
+	0x3:   0x23209, // integrity
+	0x4:   0x43106, // source
+	0x5:   0x2c09,  // accesskey
+	0x6:   0x1a06,  // accept
+	0x7:   0x6c807, // onwheel
+	0xb:   0x47407, // onkeyup
+	0xc:   0x32007, // headers
+	0xd:   0x67306, // scoped
+	0xe:   0x67909, // onsuspend
+	0xf:   0x8908,  // noframes
+	0x10:  0x1fa0b, // crossorigin
+	0x11:  0x2e407, // onclick
+	0x12:  0x3f405, // start
+	0x13:  0x37a0b, // contextmenu
+	0x14:  0x5e903, // src
+	0x15:  0x1c404, // cols
+	0x16:  0xbb06,  // dialog
+	0x17:  0x47a07, // preload
+	0x18:  0x3c707, // itemref
+	0x1b:  0x2f105, // image
+	0x1d:  0x4ba09, // onloadend
+	0x1e:  0x45d08, // download
+	0x1f:  0x46a03, // pre
+	0x23:  0x2970a, // formmethod
+	0x24:  0x71303, // svg
+	0x25:  0xcf01,  // q
+	0x26:  0x64002, // dt
+	0x27:  0x1de08, // controls
+	0x2a:  0x2804,  // body
+	0x2b:  0xd206,  // strike
+	0x2c:  0x3910b, // oncuechange
+	0x2d:  0x4c30b, // onloadstart
+	0x2e:  0x2fe07, // isindex
+	0x2f:  0xb202,  // li
+	0x30:  0x1400b, // playsinline
+	0x31:  0x34102, // mi
+	0x32:  0x30806, // applet
+	0x33:  0x4ce09, // onmessage
+	0x35:  0x13702, // ol
+	0x36:  0x1a304, // open
+	0x39:  0x14d09, // oncanplay
+	0x3a:  0x6bf09, // onwaiting
+	0x3b:  0x11908, // oncancel
+	0x3c:  0x6a908, // onunload
+	0x3e:  0x53c09, // onoffline
+	0x3f:  0x1a0e,  // accept-charset
+	0x40:  0x32004, // head
+	0x42:  0x3ab09, // ondragend
+	0x43:  0x1310b, // placeholder
+	0x44:  0x2b30a, // formtarget
+	0x45:  0x2540d, // foreignobject
+	0x47:  0x400c,  // ontimeupdate
+	0x48:  0xdd0e,  // allowusermedia
+	0x4a:  0x69c0d, // onbeforeprint
+	0x4b:  0x5604,  // html
+	0x4c:  0x9f04,  // span
+	0x4d:  0x64206, // hgroup
+	0x4e:  0x16408, // disabled
+	0x4f:  0x4204,  // time
+	0x51:  0x42b07, // onfocus
+	0x53:  0xb00a,  // malignmark
+	0x55:  0x4650a, // onkeypress
+	0x56:  0x55805, // class
+	0x57:  0x1ab08, // colgroup
+	0x58:  0x33709, // maxlength
+	0x59:  0x5a908, // progress
+	0x5b:  0x70405, // style
+	0x5c:  0x2a10e, // formnovalidate
+	0x5e:  0x38b06, // oncopy
+	0x60:  0x26104, // form
+	0x61:  0xf606,  // footer
+	0x64:  0x30a,   // radiogroup
+	0x66:  0xfb04,  // ruby
+	0x67:  0x4ff0b, // onmousemove
+	0x68:  0x19d08, // itemprop
+	0x69:  0x2d70a, // http-equiv
+	0x6a:  0x15602, // th
+	0x6c:  0x6e02,  // em
+	0x6d:  0x38108, // menuitem
+	0x6e:  0x63106, // select
+	0x6f:  0x48110, // onlanguagechange
+	0x70:  0x31f05, // thead
+	0x71:  0x15c02, // h1
+	0x72:  0x5e906, // srcdoc
+	0x75:  0x9604,  // name
+	0x76:  0x19106, // button
+	0x77:  0x55504, // desc
+	0x78:  0x17704, // kind
+	0x79:  0x1bf05, // color
+	0x7c:  0x58e06, // usemap
+	0x7d:  0x30e08, // itemtype
+	0x7f:  0x6d508, // manifest
+	0x81:  0x5300c, // onmousewheel
+	0x82:  0x4dc0b, // onmousedown
+	0x84:  0xc05,   // param
+	0x85:  0x2e005, // video
+	0x86:  0x4910c, // onloadeddata
+	0x87:  0x6f107, // address
+	0x8c:  0xef04,  // ping
+	0x8d:  0x24703, // for
+	0x8f:  0x62f08, // onselect
+	0x90:  0x30703, // map
+	0x92:  0xc01,   // p
+	0x93:  0x8008,  // reversed
+	0x94:  0x54d0a, // onpagehide
+	0x95:  0x3206,  // keygen
+	0x96:  0x34109, // minlength
+	0x97:  0x3e40a, // ondragover
+	0x98:  0x42407, // onerror
+	0x9a:  0x2107,  // charset
+	0x9b:  0x29b06, // method
+	0x9c:  0x101,   // b
+	0x9d:  0x68208, // ontoggle
+	0x9e:  0x2bd06, // hidden
+	0xa0:  0x3f607, // article
+	0xa2:  0x63906, // onshow
+	0xa3:  0x64d06, // onsort
+	0xa5:  0x57b0f, // contenteditable
+	0xa6:  0x66908, // onsubmit
+	0xa8:  0x44f09, // oninvalid
+	0xaa:  0x202,   // br
+	0xab:  0x10902, // id
+	0xac:  0x5d04,  // loop
+	0xad:  0x5630a, // onpageshow
+	0xb0:  0x2cf04, // href
+	0xb2:  0x2210a, // figcaption
+	0xb3:  0x2690e, // onautocomplete
+	0xb4:  0x49106, // onload
+	0xb6:  0x9c04,  // rows
+	0xb7:  0x1a605, // nonce
+	0xb8:  0x68a14, // onunhandledrejection
+	0xbb:  0x21306, // center
+	0xbc:  0x59406, // onplay
+	0xbd:  0x33f02, // h5
+	0xbe:  0x49d07, // listing
+	0xbf:  0x57606, // public
+	0xc2:  0x23b06, // figure
+	0xc3:  0x57a04, // icon
+	0xc4:  0x1ab03, // col
+	0xc5:  0x47b03, // rel
+	0xc6:  0xe605,  // media
+	0xc7:  0x12109, // autofocus
+	0xc8:  0x19a02, // rt
+	0xca:  0x2d304, // lang
+	0xcc:  0x49908, // datalist
+	0xce:  0x2eb06, // iframe
+	0xcf:  0x36105, // muted
+	0xd0:  0x6140a, // onauxclick
+	0xd2:  0x3c02,  // as
+	0xd6:  0x3fd06, // ondrop
+	0xd7:  0x1c90a, // annotation
+	0xd8:  0x21908, // fieldset
+	0xdb:  0x2cf08, // hreflang
+	0xdc:  0x4e70c, // onmouseenter
+	0xdd:  0x2a402, // mn
+	0xde:  0xe60a,  // mediagroup
+	0xdf:  0x9805,  // meter
+	0xe0:  0x56c03, // wbr
+	0xe2:  0x63e05, // width
+	0xe3:  0x2290c, // onafterprint
+	0xe4:  0x30505, // ismap
+	0xe5:  0x1505,  // value
+	0xe7:  0x1303,  // nav
+	0xe8:  0x54508, // ononline
+	0xe9:  0xb604,  // mark
+	0xea:  0xc303,  // low
+	0xeb:  0x3ee0b, // ondragstart
+	0xef:  0x12f03, // xmp
+	0xf0:  0x22407, // caption
+	0xf1:  0xd904,  // type
+	0xf2:  0x70907, // summary
+	0xf3:  0x6802,  // tt
+	0xf4:  0x20809, // translate
+	0xf5:  0x1870a, // blockquote
+	0xf8:  0x15702, // hr
+	0xfa:  0x2705,  // tbody
+	0xfc:  0x7b07,  // picture
+	0xfd:  0x5206,  // height
+	0xfe:  0x19c04, // cite
+	0xff:  0x2501,  // s
+	0x101: 0xff05,  // async
+	0x102: 0x56f07, // onpaste
+	0x103: 0x19507, // onabort
+	0x104: 0x2b706, // target
+	0x105: 0x14b03, // bdo
+	0x106: 0x1f006, // coords
+	0x107: 0x5e108, // onresize
+	0x108: 0x71908, // template
+	0x10a: 0x3a02,  // rb
+	0x10b: 0x2a50a, // novalidate
+	0x10c: 0x460e,  // updateviacache
+	0x10d: 0x71003, // sup
+	0x10e: 0x6c07,  // noembed
+	0x10f: 0x16b03, // div
+	0x110: 0x6f707, // srclang
+	0x111: 0x17a09, // draggable
+	0x112: 0x67305, // scope
+	0x113: 0x5905,  // label
+	0x114: 0x22f02, // rp
+	0x115: 0x23f08, // required
+	0x116: 0x3780d, // oncontextmenu
+	0x117: 0x5e504, // size
+	0x118: 0x5b00a, // spellcheck
+	0x119: 0x3f04,  // font
+	0x11a: 0x9c07,  // rowspan
+	0x11b: 0x10a07, // default
+	0x11d: 0x44307, // oninput
+	0x11e: 0x38506, // itemid
+	0x11f: 0x5ee04, // code
+	0x120: 0xaa07,  // acronym
+	0x121: 0x3b04,  // base
+	0x125: 0x2470d, // foreignObject
+	0x126: 0x2ca04, // high
+	0x127: 0x3cb0e, // referrerpolicy
+	0x128: 0x33703, // max
+	0x129: 0x59d0a, // onpopstate
+	0x12a: 0x2fc02, // h4
+	0x12b: 0x4ac04, // meta
+	0x12c: 0x17305, // blink
+	0x12e: 0x5f508, // onscroll
+	0x12f: 0x59409, // onplaying
+	0x130: 0xc113,  // allowpaymentrequest
+	0x131: 0x19a03, // rtc
+	0x132: 0x72b04, // wrap
+	0x134: 0x8b08,  // frameset
+	0x135: 0x32605, // small
+	0x137: 0x32006, // header
+	0x138: 0x40409, // onemptied
+	0x139: 0x34902, // h6
+	0x13a: 0x35908, // multiple
+	0x13c: 0x52a06, // prompt
+	0x13f: 0x28e09, // challenge
+	0x141: 0x4370c, // onhashchange
+	0x142: 0x57b07, // content
+	0x143: 0x1c90e, // annotation-xml
+	0x144: 0x36607, // onclose
+	0x145: 0x14d10, // oncanplaythrough
+	0x148: 0x5170b, // onmouseover
+	0x149: 0x64f08, // sortable
+	0x14a: 0xa402,  // mo
+	0x14b: 0x2cd02, // h3
+	0x14c: 0x2c406, // script
+	0x14d: 0x41d07, // onended
+	0x14f: 0x64706, // poster
+	0x150: 0x7210a, // workertype
+	0x153: 0x1f505, // shape
+	0x154: 0x4,     // abbr
+	0x155: 0x1,     // a
+	0x156: 0x2bf02, // dd
+	0x157: 0x71606, // system
+	0x158: 0x4ce0e, // onmessageerror
+	0x159: 0x36b08, // seamless
+	0x15a: 0x2610a, // formaction
+	0x15b: 0x6e106, // option
+	0x15c: 0x31d04, // math
+	0x15d: 0x62609, // onseeking
+	0x15e: 0x39c05, // oncut
+	0x15f: 0x44c03, // del
+	0x160: 0x11005, // title
+	0x161: 0x11505, // audio
+	0x162: 0x63108, // selected
+	0x165: 0x3b40b, // ondragenter
+	0x166: 0x46e06, // spacer
+	0x167: 0x4a410, // onloadedmetadata
+	0x168: 0x44505, // input
+	0x16a: 0x58505, // table
+	0x16b: 0x41508, // onchange
+	0x16e: 0x5f005, // defer
+	0x171: 0x50a0a, // onmouseout
+	0x172: 0x20504, // slot
+	0x175: 0x3704,  // nobr
+	0x177: 0x1d707, // command
+	0x17a: 0x7207,  // details
+	0x17b: 0x38104, // menu
+	0x17c: 0xb903,  // kbd
+	0x17d: 0x57304, // step
+	0x17e: 0x20303, // ins
+	0x17f: 0x13c08, // autoplay
+	0x182: 0x34103, // min
+	0x183: 0x17404, // link
+	0x185: 0x40d10, // ondurationchange
+	0x186: 0x9202,  // td
+	0x187: 0x8b05,  // frame
+	0x18a: 0x2ab08, // datetime
+	0x18b: 0x44509, // inputmode
+	0x18c: 0x35108, // readonly
+	0x18d: 0x21104, // face
+	0x18f: 0x5e505, // sizes
+	0x191: 0x4b208, // tabindex
+	0x192: 0x6db06, // strong
+	0x193: 0xba03,  // bdi
+	0x194: 0x6fe06, // srcset
+	0x196: 0x67202, // ms
+	0x197: 0x5b507, // checked
+	0x198: 0xb105,  // align
+	0x199: 0x1e507, // section
+	0x19b: 0x6e05,  // embed
+	0x19d: 0x15e07, // bgsound
+	0x1a2: 0x49d04, // list
+	0x1a3: 0x61e08, // onseeked
+	0x1a4: 0x66009, // onstorage
+	0x1a5: 0x2f603, // img
+	0x1a6: 0xf505,  // tfoot
+	0x1a9: 0x26913, // onautocompleteerror
+	0x1aa: 0x5fd19, // onsecuritypolicyviolation
+	0x1ad: 0x9303,  // dir
+	0x1ae: 0x9307,  // dirname
+	0x1b0: 0x5a70a, // onprogress
+	0x1b2: 0x65709, // onstalled
+	0x1b5: 0x66f09, // itemscope
+	0x1b6: 0x49904, // data
+	0x1b7: 0x3d90b, // ondragleave
+	0x1b8: 0x56102, // h2
+	0x1b9: 0x2f706, // mglyph
+	0x1ba: 0x16502, // is
+	0x1bb: 0x6e50e, // onbeforeunload
+	0x1bc: 0x2830d, // typemustmatch
+	0x1bd: 0x3ab06, // ondrag
+	0x1be: 0x5da07, // onreset
+	0x1c0: 0x51106, // output
+	0x1c1: 0x12907, // sandbox
+	0x1c2: 0x1b209, // plaintext
+	0x1c4: 0x34c08, // textarea
+	0x1c7: 0xd607,  // keytype
+	0x1c8: 0x34b05, // mtext
+	0x1c9: 0x6b10e, // onvolumechange
+	0x1ca: 0x1ea06, // onblur
+	0x1cb: 0x58a07, // onpause
+	0x1cd: 0x5bc0c, // onratechange
+	0x1ce: 0x10705, // aside
+	0x1cf: 0x6cf07, // optimum
+	0x1d1: 0x45809, // onkeydown
+	0x1d2: 0x1c407, // colspan
+	0x1d3: 0x1004,  // main
+	0x1d4: 0x66b03, // sub
+	0x1d5: 0x25b06, // object
+	0x1d6: 0x55c06, // search
+	0x1d7: 0x37206, // sorted
+	0x1d8: 0x17003, // big
+	0x1d9: 0xb01,   // u
+	0x1db: 0x26b0c, // autocomplete
+	0x1dc: 0xcc02,  // tr
+	0x1dd: 0xf303,  // alt
+	0x1df: 0x7804,  // samp
+	0x1e0: 0x5c812, // onrejectionhandled
+	0x1e1: 0x4f30c, // onmouseleave
+	0x1e2: 0x28007, // enctype
+	0x1e3: 0xa208,  // nomodule
+	0x1e5: 0x3280f, // allowfullscreen
+	0x1e6: 0x5f08,  // optgroup
+	0x1e8: 0x27c0b, // formenctype
+	0x1e9: 0x18106, // legend
+	0x1ea: 0x10306, // canvas
+	0x1eb: 0x6607,  // pattern
+	0x1ec: 0x2c208, // noscript
+	0x1ed: 0x601,   // i
+	0x1ee: 0x5d602, // dl
+	0x1ef: 0xa702,  // ul
+	0x1f2: 0x52209, // onmouseup
+	0x1f4: 0x1ba05, // track
+	0x1f7: 0x3a10a, // ondblclick
+	0x1f8: 0x3bf0a, // ondragexit
+	0x1fa: 0x8703,  // dfn
+	0x1fc: 0x26506, // action
+	0x1fd: 0x35004, // area
+	0x1fe: 0x31607, // marquee
+	0x1ff: 0x16d03, // var
 }
 
 const atomText = "abbradiogrouparamainavalueaccept-charsetbodyaccesskeygenobrb" +
@@ -758,26 +760,26 @@ const atomText = "abbradiogrouparamainavalueaccept-charsetbodyaccesskeygenobrb" 
 	"dboxmplaceholderautoplaysinlinebdoncanplaythrough1bgsoundisa" +
 	"bledivarbigblinkindraggablegendblockquotebuttonabortcitempro" +
 	"penoncecolgrouplaintextrackcolorcolspannotation-xmlcommandco" +
-	"ntrolshapecoordslotranslatecrossoriginsmallowfullscreenoscri" +
-	"ptfacenterfieldsetfigcaptionafterprintegrityfigurequiredfore" +
-	"ignObjectforeignobjectformactionautocompleteerrorformenctype" +
-	"mustmatchallengeformmethodformnovalidatetimeformtargethgroup" +
-	"osterhiddenhigh2hreflanghttp-equivideonclickiframeimageimgly" +
-	"ph3isindexismappletitemtypemarqueematheadersortedmaxlength4m" +
-	"inlength5mtextareadonlymultiplemutedoncloseamlessourceoncont" +
-	"extmenuitemidoncopyoncuechangeoncutondblclickondragendondrag" +
-	"enterondragexitemreferrerpolicyondragleaveondragoverondragst" +
-	"articleondropzonemptiedondurationchangeonendedonerroronfocus" +
-	"paceronhashchangeoninputmodeloninvalidonkeydownloadonkeypres" +
-	"spellcheckedonkeyupreloadonlanguagechangeonloadeddatalisting" +
-	"onloadedmetadatabindexonloadendonloadstartonmessageerroronmo" +
-	"usedownonmouseenteronmouseleaveonmousemoveonmouseoutputonmou" +
-	"seoveronmouseupromptonmousewheelonofflineononlineonpagehides" +
-	"classectionbluronpageshowbronpastepublicontenteditableonpaus" +
-	"emaponplayingonpopstateonprogressrcdocodeferonratechangeonre" +
-	"jectionhandledonresetonresizesrclangonscrollonsecuritypolicy" +
-	"violationauxclickonseekedonseekingonselectedonshowidth6onsor" +
-	"tableonstalledonstorageonsubmitemscopedonsuspendontoggleonun" +
-	"handledrejectionbeforeprintonunloadonvolumechangeonwaitingon" +
-	"wheeloptimumanifestrongoptionbeforeunloaddressrcsetstylesumm" +
-	"arysupsvgsystemplateworkertypewrap"
+	"ntrolsectionblurcoordshapecrossoriginslotranslatefacenterfie" +
+	"ldsetfigcaptionafterprintegrityfigurequiredforeignObjectfore" +
+	"ignobjectformactionautocompleteerrorformenctypemustmatchalle" +
+	"ngeformmethodformnovalidatetimeformtargethiddenoscripthigh3h" +
+	"reflanghttp-equivideonclickiframeimageimglyph4isindexismappl" +
+	"etitemtypemarqueematheadersmallowfullscreenmaxlength5minleng" +
+	"th6mtextareadonlymultiplemutedoncloseamlessortedoncontextmen" +
+	"uitemidoncopyoncuechangeoncutondblclickondragendondragentero" +
+	"ndragexitemreferrerpolicyondragleaveondragoverondragstarticl" +
+	"eondropzonemptiedondurationchangeonendedonerroronfocusourceo" +
+	"nhashchangeoninputmodeloninvalidonkeydownloadonkeypresspacer" +
+	"onkeyupreloadonlanguagechangeonloadeddatalistingonloadedmeta" +
+	"databindexonloadendonloadstartonmessageerroronmousedownonmou" +
+	"seenteronmouseleaveonmousemoveonmouseoutputonmouseoveronmous" +
+	"eupromptonmousewheelonofflineononlineonpagehidesclassearch2o" +
+	"npageshowbronpastepublicontenteditableonpausemaponplayingonp" +
+	"opstateonprogresspellcheckedonratechangeonrejectionhandledon" +
+	"resetonresizesrcdocodeferonscrollonsecuritypolicyviolationau" +
+	"xclickonseekedonseekingonselectedonshowidthgrouposteronsorta" +
+	"bleonstalledonstorageonsubmitemscopedonsuspendontoggleonunha" +
+	"ndledrejectionbeforeprintonunloadonvolumechangeonwaitingonwh" +
+	"eeloptimumanifestrongoptionbeforeunloaddressrclangsrcsetstyl" +
+	"esummarysupsvgsystemplateworkertypewrap"

--- a/vendor/golang.org/x/net/html/parse.go
+++ b/vendor/golang.org/x/net/html/parse.go
@@ -924,7 +924,7 @@ func inBodyIM(p *parser) bool {
 			p.addElement()
 			p.im = inFramesetIM
 			return true
-		case a.Address, a.Article, a.Aside, a.Blockquote, a.Center, a.Details, a.Dialog, a.Dir, a.Div, a.Dl, a.Fieldset, a.Figcaption, a.Figure, a.Footer, a.Header, a.Hgroup, a.Main, a.Menu, a.Nav, a.Ol, a.P, a.Section, a.Summary, a.Ul:
+		case a.Address, a.Article, a.Aside, a.Blockquote, a.Center, a.Details, a.Dialog, a.Dir, a.Div, a.Dl, a.Fieldset, a.Figcaption, a.Figure, a.Footer, a.Header, a.Hgroup, a.Main, a.Menu, a.Nav, a.Ol, a.P, a.Search, a.Section, a.Summary, a.Ul:
 			p.popUntil(buttonScope, a.P)
 			p.addElement()
 		case a.H1, a.H2, a.H3, a.H4, a.H5, a.H6:
@@ -1136,7 +1136,7 @@ func inBodyIM(p *parser) bool {
 				return false
 			}
 			return true
-		case a.Address, a.Article, a.Aside, a.Blockquote, a.Button, a.Center, a.Details, a.Dialog, a.Dir, a.Div, a.Dl, a.Fieldset, a.Figcaption, a.Figure, a.Footer, a.Header, a.Hgroup, a.Listing, a.Main, a.Menu, a.Nav, a.Ol, a.Pre, a.Section, a.Summary, a.Ul:
+		case a.Address, a.Article, a.Aside, a.Blockquote, a.Button, a.Center, a.Details, a.Dialog, a.Dir, a.Div, a.Dl, a.Fieldset, a.Figcaption, a.Figure, a.Footer, a.Header, a.Hgroup, a.Listing, a.Main, a.Menu, a.Nav, a.Ol, a.Pre, a.Search, a.Section, a.Summary, a.Ul:
 			p.popUntil(defaultScope, p.tok.DataAtom)
 		case a.Form:
 			if p.oe.contains(a.Template) {

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -225,6 +225,11 @@ var fhBytes = sync.Pool{
 	},
 }
 
+func invalidHTTP1LookingFrameHeader() FrameHeader {
+	fh, _ := readFrameHeader(make([]byte, frameHeaderLen), strings.NewReader("HTTP/1.1 "))
+	return fh
+}
+
 // ReadFrameHeader reads 9 bytes from r and returns a FrameHeader.
 // Most users should use Framer.ReadFrame instead.
 func ReadFrameHeader(r io.Reader) (FrameHeader, error) {
@@ -503,10 +508,16 @@ func (fr *Framer) ReadFrame() (Frame, error) {
 		return nil, err
 	}
 	if fh.Length > fr.maxReadSize {
+		if fh == invalidHTTP1LookingFrameHeader() {
+			return nil, fmt.Errorf("http2: failed reading the frame payload: %w, note that the frame header looked like an HTTP/1.1 header", err)
+		}
 		return nil, ErrFrameTooLarge
 	}
 	payload := fr.getReadBuf(fh.Length)
 	if _, err := io.ReadFull(fr.r, payload); err != nil {
+		if fh == invalidHTTP1LookingFrameHeader() {
+			return nil, fmt.Errorf("http2: failed reading the frame payload: %w, note that the frame header looked like an HTTP/1.1 header", err)
+		}
 		return nil, err
 	}
 	f, err := typeFrameParser(fh.Type)(fr.frameCache, fh, fr.countError, payload)

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -1068,7 +1068,10 @@ func (sc *serverConn) serve(conf http2Config) {
 
 func (sc *serverConn) handlePingTimer(lastFrameReadTime time.Time) {
 	if sc.pingSent {
-		sc.vlogf("timeout waiting for PING response")
+		sc.logf("timeout waiting for PING response")
+		if f := sc.countErrorFunc; f != nil {
+			f("conn_close_lost_ping")
+		}
 		sc.conn.Close()
 		return
 	}

--- a/vendor/golang.org/x/net/websocket/websocket.go
+++ b/vendor/golang.org/x/net/websocket/websocket.go
@@ -6,9 +6,10 @@
 // as specified in RFC 6455.
 //
 // This package currently lacks some features found in an alternative
-// and more actively maintained WebSocket package:
+// and more actively maintained WebSocket packages:
 //
-//	https://pkg.go.dev/github.com/coder/websocket
+//   - [github.com/gorilla/websocket]
+//   - [github.com/coder/websocket]
 package websocket // import "golang.org/x/net/websocket"
 
 import (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -278,7 +278,7 @@ github.com/munnerz/goautoneg
 # github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 ## explicit
 github.com/mxk/go-flowrate/flowrate
-# github.com/onsi/gomega v1.36.3
+# github.com/onsi/gomega v1.37.0
 ## explicit; go 1.23.0
 github.com/onsi/gomega
 github.com/onsi/gomega/format

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -439,7 +439,7 @@ go.uber.org/zap/zapcore
 ## explicit; go 1.22.0
 golang.org/x/exp/maps
 golang.org/x/exp/slices
-# golang.org/x/net v0.37.0
+# golang.org/x/net v0.38.0
 ## explicit; go 1.23.0
 golang.org/x/net/context
 golang.org/x/net/html


### PR DESCRIPTION
# Changes

Codebase is tracking https://github.com/shipwright-io/cli/pull/304 as `.spec.NodeSelector` is only defined on `builds.shipwright.io/v1beta1`. The current `main` branch for CLI still relies on `builds.shipwright.io/v1alpha1`

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

# Release Notes

```
Add flag --node to set the `.spec.nodeSelector` for `build` and `buildrun` on create
```
